### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.nextpvr/addon.xml
+++ b/pvr.nextpvr/addon.xml
@@ -6,7 +6,7 @@
   provider-name="Graeme Blackley">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
     <import addon="xbmc.gui" version="5.8.0"/>
   </requires>
   <extension

--- a/pvr.nextpvr/addon.xml
+++ b/pvr.nextpvr/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="1.10.6"
+  version="1.11.0"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v1.11.0
+- Updated to PVR API v1.9.7
+
 v1.10.6
 - updated language files from Transifex
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -511,6 +511,12 @@ PVR_ERROR RenameRecording(const PVR_RECORDING &recording)
 /*******************************************/
 /** PVR Timer Functions                   **/
 
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+  /* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 int GetTimersAmount(void)
 {
   if (!g_client)
@@ -521,6 +527,7 @@ int GetTimersAmount(void)
 
 PVR_ERROR GetTimers(ADDON_HANDLE handle)
 {
+  /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
   if (!g_client)
     return PVR_ERROR_SERVER_ERROR;
   else
@@ -535,8 +542,9 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
     return g_client->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/)
 {
+  /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
   if (!g_client)
     return PVR_ERROR_SERVER_ERROR;
   else

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -1034,6 +1034,10 @@ PVR_ERROR cPVRClientNextPVR::GetTimers(ADDON_HANDLE handle)
       for( pRecurringNode = recurringsNode->FirstChildElement("recurring"); pRecurringNode; pRecurringNode=pRecurringNode->NextSiblingElement())
       {
         memset(&tag, 0, sizeof(tag));
+
+        /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+        tag.iTimerType = PVR_TIMER_TYPE_NONE;
+
         tag.iClientIndex = 0xF000000 + atoi(pRecurringNode->FirstChildElement("id")->FirstChild()->Value());
 
         tag.iClientChannelUid = 8101;
@@ -1052,8 +1056,6 @@ PVR_ERROR cPVRClientNextPVR::GetTimers(ADDON_HANDLE handle)
         tag.endTime = time(NULL) - 86000;
         
         PVR_STRCPY(tag.strSummary, "summary");
-
-        tag.bIsRepeating = true;
 
         // pass timer to xbmc
         PVR->TransferTimerEntry(handle, &tag);
@@ -1076,6 +1078,8 @@ PVR_ERROR cPVRClientNextPVR::GetTimers(ADDON_HANDLE handle)
       {
         memset(&tag, 0, sizeof(tag));
 
+        /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+        tag.iTimerType = PVR_TIMER_TYPE_NONE;
 
         tag.iClientIndex = atoi(pRecordingNode->FirstChildElement("id")->FirstChild()->Value());
         tag.iClientChannelUid = atoi(pRecordingNode->FirstChildElement("channel_id")->FirstChild()->Value());
@@ -1107,15 +1111,6 @@ PVR_ERROR cPVRClientNextPVR::GetTimers(ADDON_HANDLE handle)
         start[10] = '\0';
         tag.startTime           = atol(start);
         tag.endTime             = tag.startTime + atoi(pRecordingNode->FirstChildElement("duration_seconds")->FirstChild()->Value());
-
-        // recurring recordings
-        if (pRecordingNode->FirstChildElement("recurring") != NULL && pRecordingNode->FirstChildElement("recurring")->FirstChild() != NULL)
-        {
-          if (strcmp(pRecordingNode->FirstChildElement("recurring")->FirstChild()->Value(), "true") == 0)
-          {
-            tag.bIsRepeating = true;
-          }
-        }
 
         // pass timer to xbmc
         PVR->TransferTimerEntry(handle, &tag);


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.