### PR TITLE
Fix: GetBackendName() function returns only the Hostname.

### DIFF
--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -321,7 +321,7 @@ bool cPVRClientNextPVR::IsUp()
 // Used among others for the server name string in the "Recordings" view
 const char* cPVRClientNextPVR::GetBackendName(void)
 {
-  if (!m_tcpclient->is_valid())
+  if (!m_bConnected)
   {
     return g_szHostname.c_str();
   }


### PR DESCRIPTION
Hi,

I use `GetBackendName()` method in [Kodi DSPlayer](http://forum.kodi.tv/showthread.php?tid=223175&pid=2015166#pid2015166) to find which PVR Addon is running.

NextPVR addon returns only the Hostname without the pvr addon name.

```
const char* cPVRClientNextPVR::GetBackendName(void)
{
  if (!m_tcpclient->is_valid())
  {
    return g_szHostname.c_str();
  }

  XBMC->Log(LOG_DEBUG, "->GetBackendName()");
  
  if (m_BackendName.length() == 0)
  {
    m_BackendName = "NextPVR  (";
    m_BackendName += g_szHostname.c_str();
    m_BackendName += ")";
  }

  return m_BackendName.c_str();
}
```

The reason for this issue is that the socket `m_tcpclient` is always closed, it is only valid while the function `cPVRClientNextPVR::GetChannelIcon()` is executing.


```
CStdString cPVRClientNextPVR::GetChannelIcon(int channelID)
{
  char filename[64];
  snprintf(filename, sizeof(filename), "nextpvr-ch%d.png", channelID);

  CStdString iconFilename("special://userdata/addon_data/pvr.nextpvr/");
  iconFilename += filename;

  // do we already have the icon file?
  if (XBMC->FileExists(iconFilename, false))
  {        
    return iconFilename;    
  } 

  if (m_tcpclient->create())
  {
    if (m_tcpclient->connect(g_szHostname, g_iPort))
    {
      char line[256];
      sprintf(line, "GET /service?method=channel.icon&channel_id=%d HTTP/1.0\r\n", channelID);
      m_tcpclient->send(line, strlen(line));

      sprintf(line, "Connection: close\r\n");
      m_tcpclient->send(line, strlen(line));

      sprintf(line, "\r\n");
      m_tcpclient->send(line, strlen(line));

      char buf[1024];
      int read = m_tcpclient->receive(buf, sizeof buf, 0);
      if (read > 0)
      {
        void* fileHandle = XBMC->OpenFileForWrite(iconFilename, true);
        if (fileHandle != NULL)
        {
          int written = 0;
          // HTTP response header
          for (int i=0; i<read; i++)
          {
            if (buf[i] == '\r' && buf[i+1] == '\n' && buf[i+2] == '\r' && buf[i+3] == '\n')
            {
              XBMC->WriteFile(fileHandle, (unsigned char *)&buf[i+4], (read - (i + 4)));
            }
          }

          // rest of body
          bool connected = true;
          while (connected)
          {
            char buf[1024];
            int read = m_tcpclient->receive(buf, sizeof buf, 0);

            if (read == 0)
            {
              connected = false;
            }
            else if (read > 0)
            {
              XBMC->WriteFile(fileHandle, (unsigned char *)buf, read);
            }
            else if (read < 0 && written > 0)
            {
              connected = false;
            }
          }

          // close file
          XBMC->CloseFile(fileHandle);
        }
      }
    }
    m_tcpclient->close();
    return iconFilename;
  }


  return "";
}
```