### PR TITLE
Fix: GetLiveStreamURL() - live stream url does not contain the sub-channel number.

### DIFF
--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -1345,7 +1345,10 @@ bool cPVRClientNextPVR::OpenLiveStream(const PVR_CHANNEL &channelinfo)
         // long blocking from now on
         m_streamingclient->set_non_blocking(1);
 
-        snprintf(line, sizeof(line), "http://%s:%d/live?channel=%d&client=XBMC", g_szHostname.c_str(), g_iPort, channelinfo.iChannelNumber);
+        if (channelinfo.iSubChannelNumber == 0)
+          snprintf(line, sizeof(line), "http://%s:%d/live?channel=%d&client=XBMC", g_szHostname.c_str(), g_iPort, channelinfo.iChannelNumber);
+        else
+          snprintf(line, sizeof(line), "http://%s:%d/live?channel=%d.%d&client=XBMC", g_szHostname.c_str(), g_iPort, channelinfo.iChannelNumber, channelinfo.iSubChannelNumber);
         m_PlaybackURL = line;
 
 


### PR DESCRIPTION
﻿Hi,

I use `cPVRClientNextPVR::GetLiveStreamURL()` method to get live stream url and pass it to the external reader([DSPlayer](http://forum.kodi.tv/showthread.php?tid=223175&pid=2015166#pid2015166)). 

The issue is that the live stream url does not contain the sub-channel number, but only the channel number.