### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(TinyXML REQUIRED)

--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="2.3.1"
+  version="2.4.0"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v2.4.0
+- Cmake: rename find_package kodi to Kodi
+
 v2.3.1
 - Fix includes
 


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in