### PR TITLE
Update to 5.7.0 PVR addon API to work with Kodi 18 (Leia)

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="3.1.1"
+  version="3.2.0"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v3.2.0
+- Updated to PVR addon API 5.7.0
+
 v3.1.0
 - Updated to PVR addon API v5.3.0
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -582,14 +582,6 @@ long long LengthLiveStream(void)
     return g_client->LengthLiveStream();
 }
 
-bool SwitchChannel(const PVR_CHANNEL &channelinfo)
-{
-  if (!g_client)
-    return false;
-  else
-    return g_client->SwitchChannel(channelinfo);
-}
-
 PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
 {
   if (!g_client)
@@ -647,14 +639,6 @@ long long LengthRecordedStream(void)
     return g_client->LengthRecordedStream();
 }
 
-const char * GetLiveStreamURL(const PVR_CHANNEL &channel)
-{
-  if (!g_client)
-    return "";
-  else
-    return g_client->GetLiveStreamURL(channel);
-}
-
 bool CanPauseStream(void)
 {
   if (g_client)
@@ -694,6 +678,24 @@ PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recording, PVR_EDL_ENTRY entries[
   return PVR_ERROR_SERVER_ERROR;
 }
 
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* props, unsigned int* prop_size)
+{
+  if ((!channel) || (!props) || (!prop_size))
+    return PVR_ERROR_FAILED;
+  if (g_client)
+    return g_client->GetChannelStreamProperties(channel, props, prop_size);
+  return PVR_ERROR_SERVER_ERROR; 
+}
+
+PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED_VALUE* props, unsigned int* prop_size)
+{ 
+  if ((!recording) || (!props) || (!prop_size))
+    return PVR_ERROR_FAILED;
+  if (g_client)
+    return g_client->GetRecordingStreamProperties(recording, props, prop_size);
+  return PVR_ERROR_SERVER_ERROR; 
+}
+
 
 /** UNUSED API FUNCTIONS */
 PVR_ERROR MoveChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
@@ -703,7 +705,6 @@ void DemuxReset(void) {}
 void DemuxFlush(void) {}
 
 PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { return PVR_ERROR_NOT_IMPLEMENTED; }
-unsigned int GetChannelSwitchDelay(void) { return 0; }
 
 bool SeekTime(double,bool,double*) { return false; }
 void SetSpeed(int) {};
@@ -712,9 +713,13 @@ bool IsRealTimeStream(void) { return true; }
 time_t GetPlayingTime() { return 0; }
 time_t GetBufferTimeStart() { return 0; }
 time_t GetBufferTimeEnd() { return 0; }
+PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteAllRecordingsFromTrash() { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR IsEPGTagRecordable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR IsEPGTagPlayable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 } //end extern "C"

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -93,7 +93,8 @@ public:
   /* Channel handling */
   int GetNumChannels(void);
   PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);  
-
+  PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*);
+  
   /* Channel group handling */
   int GetChannelGroupsAmount(void);
   PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio);
@@ -107,7 +108,8 @@ public:
   PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition);
   int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording);
   PVR_ERROR GetRecordingEdl(const PVR_RECORDING& recording, PVR_EDL_ENTRY[], int *size);
-
+  PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*);
+  
   /* Timer handling */
   int GetNumTimers(void);
   PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size);
@@ -121,9 +123,7 @@ public:
   bool OpenLiveStream(const PVR_CHANNEL &channel);
   void CloseLiveStream();
   int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize);
-  bool SwitchChannel(const PVR_CHANNEL &channel);
   PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus);
-  const char* GetLiveStreamURL(const PVR_CHANNEL &channel);
   long long SeekLiveStream(long long iPosition, int iWhence = SEEK_SET);
   long long LengthLiveStream(void);
   long long PositionLiveStream(void);
@@ -175,6 +175,7 @@ private:
 
   CStdString              m_PlaybackURL;
   LiveShiftSource        *m_pLiveShiftSource;
+  unsigned int            m_iLiveStreamUID;
 
   int64_t                 m_lastRecordingUpdateTime;
 


### PR DESCRIPTION
I realize this probably isn't ready to commit, but I wanted to see if I could jump start the process, so pvr.nextpvr can work again in the Leia daily builds.  I've tested this on the RPi2 platform, and the only issue I see is that live tv starts for a few seconds, stops to buffer, and then starts back up again.  That seems wrong.

Testing with a RPi3, I don't see the live tv behavior above. It seems to start and continue streaming fine.