### PR TITLE
Remove unneeded code introduced in last change.

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="3.2.0"
+  version="3.2.1"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v3.2.1
+- Remove unneeded code added in last revision
+
 v3.2.0
 - Updated to PVR addon API 5.7.0
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -678,15 +678,6 @@ PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recording, PVR_EDL_ENTRY entries[
   return PVR_ERROR_SERVER_ERROR;
 }
 
-PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* props, unsigned int* prop_size)
-{
-  if ((!channel) || (!props) || (!prop_size))
-    return PVR_ERROR_FAILED;
-  if (g_client)
-    return g_client->GetChannelStreamProperties(channel, props, prop_size);
-  return PVR_ERROR_SERVER_ERROR; 
-}
-
 PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED_VALUE* props, unsigned int* prop_size)
 { 
   if ((!recording) || (!props) || (!prop_size))
@@ -719,6 +710,7 @@ PVR_ERROR DeleteAllRecordingsFromTrash() { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*)  { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR IsEPGTagRecordable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR IsEPGTagPlayable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -754,23 +754,6 @@ PVR_ERROR cPVRClientNextPVR::GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
   return PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR cPVRClientNextPVR::GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* props, unsigned int* prop_size)
-{
-  if (OpenLiveStream(*channel) == true)
-  {
-    if (!m_PlaybackURL.empty())
-    {
-      PVR_STRCPY(props[0].strName, PVR_STREAM_PROPERTY_STREAMURL);
-      PVR_STRCPY(props[0].strValue, m_PlaybackURL.c_str());
-      *prop_size = 1;
-      return PVR_ERROR_NO_ERROR;
-    }
-    return PVR_ERROR_UNKNOWN;
-  }
-
-  return PVR_ERROR_FAILED;
-}
-
 PVR_ERROR cPVRClientNextPVR::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
 {
   std::string encodedGroupName = UriEncode(group.strGroupName);

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -93,7 +93,6 @@ public:
   /* Channel handling */
   int GetNumChannels(void);
   PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);  
-  PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*);
   
   /* Channel group handling */
   int GetChannelGroupsAmount(void);


### PR DESCRIPTION
Thanks to @ksooo  for pointing out that GetChannelStreamProperties() only needs to be implemented if PVR_CHANNEL::strStreamURL was being populated in GetChannels()