### PR TITLE
EPG based live TV, playback from files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,13 @@ set(NEXTPVR_SOURCES src/client.cpp
                     src/pvrclient-nextpvr.cpp
                     src/Socket.cpp
                     src/uri.cpp
+                    src/BackendRequest.cpp
                     src/buffers/Buffer.cpp
                     src/buffers/DummyBuffer.cpp
                     src/buffers/TimeshiftBuffer.cpp
                     src/buffers/RecordingBuffer.cpp
                     src/buffers/CircularBuffer.cpp
+                    src/buffers/EpgBasedBuffer.cpp
                     src/buffers/Seeker.cpp)
 
 set(NEXTPVR_HEADERS src/client.h
@@ -35,11 +37,13 @@ set(NEXTPVR_HEADERS src/client.h
                     src/pvrclient-nextpvr.h
                     src/Socket.h
                     src/uri.h
+                    src/BackendRequest.h
                     src/buffers/Buffer.h
                     src/buffers/DummyBuffer.h
                     src/buffers/TimeshiftBuffer.h
                     src/buffers/RecordingBuffer.h
                     src/buffers/CircularBuffer.h
+                    src/buffers/EpgBasedBuffer.h
                     src/buffers/Seeker.h)
 
 SET(DEPLIBS ${p8-platform_LIBRARIES}

--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="3.3.11"
+  version="3.3.12"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,9 @@
+v3.3.12
+- Add EPG based buffer,
+- Add share based recording playback
+- Move DoRequest to a Class
+- Fix radio, reduce spam
+
 v3.3.11
 - Fixes for live tv timeshift and seeking.
 

--- a/pvr.nextpvr/resources/settings.xml
+++ b/pvr.nextpvr/resources/settings.xml
@@ -9,7 +9,8 @@
 
   <!-- advanced -->
   <category label="30041">
-    <setting id="usetimeshift" type="bool" label="30003" default="false"/>
+    <!--setting id="usetimeshift" type="bool" label="30003" default="false"/-->
+    <setting id="livestreamingmethod" type="enum" label="Live TV Stream" values="Timeshift|EPG Based|Basic" default="Basic"/>
     <setting id="guideartwork" type="bool" label="30004" default="false"/>     
   </category>
 </settings>

--- a/src/BackendRequest.cpp
+++ b/src/BackendRequest.cpp
@@ -1,0 +1,74 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#include  "BackendRequest.h"
+
+
+#define HTTP_OK 200
+#define HTTP_NOTFOUND 404
+#define HTTP_BADREQUEST 400
+
+using namespace ADDON;
+using namespace NextPVR;
+
+namespace NextPVR
+{
+  int Request::DoRequest(const char *resource, std::string &response, char *m_sid)
+  {
+    P8PLATFORM::CLockObject lock(m_mutexRequest);
+
+// build request string, adding SID if requred
+    char strURL[1024];
+
+    if (strstr(resource, "method=session") == NULL)
+      snprintf(strURL,sizeof(strURL),"http://%s:%d%s&sid=%s", g_szHostname.c_str(), g_iPort, resource, m_sid);
+    else
+      snprintf(strURL,sizeof(strURL),"http://%s:%d%s", g_szHostname.c_str(), g_iPort, resource);
+
+    // ask XBMC to read the URL for us
+    int resultCode = HTTP_NOTFOUND;
+    void* fileHandle = XBMC->OpenFile(strURL, 0);
+    if (fileHandle)
+    {
+      char buffer[1024];
+      while (XBMC->ReadFileString(fileHandle, buffer, 1024))
+      {
+        response.append(buffer);
+      }
+      XBMC->CloseFile(fileHandle);
+      resultCode = HTTP_OK;
+      if (response.empty() || strstr(response.c_str(), "<rsp stat=\"ok\">") == NULL)
+      {
+          XBMC->Log(LOG_ERROR, "DoRequest failed, response=%s", response.c_str());
+          resultCode = HTTP_BADREQUEST;
+      }
+    }
+    return resultCode;
+  }
+  Request::Request()
+  {
+    XBMC->Log(LOG_ERROR, "%s %d", __FUNCTION__, __LINE__);
+  }
+  Request::~Request()
+  {
+    XBMC->Log(LOG_ERROR, "%s %d", __FUNCTION__, __LINE__);
+  }
+}

--- a/src/BackendRequest.h
+++ b/src/BackendRequest.h
@@ -1,0 +1,48 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <ctime>
+#include <stdio.h>
+#include <stdlib.h>
+#include <memory>
+
+
+#include "client.h"
+#include "pvrclient-nextpvr.h"
+
+#include "md5.h"
+
+
+using namespace ADDON;
+using namespace NextPVR;
+
+namespace NextPVR
+{
+  class Request
+  {
+    public:
+      int DoRequest(const char *resource, std::string &response, char *m_sid);
+
+      Request(void);
+      virtual ~Request();
+    private:
+      P8PLATFORM::CMutex        m_mutexRequest;
+  };
+}

--- a/src/buffers/Buffer.cpp
+++ b/src/buffers/Buffer.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "Buffer.h"
+#include "Filesystem.h"
 #include <sstream>
 
 using namespace timeshift;
@@ -35,8 +36,15 @@ bool Buffer::Open(const std::string inputUrl)
     // Append the read timeout parameter
     XBMC->Log(LOG_DEBUG, "Buffer::Open() called! [ %s ]", inputUrl.c_str());
     std::stringstream ss;
+    if (inputUrl.rfind("http", 0) == 0)
+    {
     ss << inputUrl << "|connection-timeout=" << m_readTimeout;
-    m_inputHandle = XBMC->OpenFile(ss.str().c_str(), 0x08 );  /*READ_NO_CACHE*/
+    }
+    else
+    {
+      ss << inputUrl;
+    }
+    m_inputHandle = XBMC->OpenFile(ss.str().c_str(), READ_NO_CACHE );
   }
   // Remember the start time and open the input
   m_startTime = time(nullptr);

--- a/src/buffers/Buffer.h
+++ b/src/buffers/Buffer.h
@@ -78,7 +78,7 @@ namespace timeshift {
     /**
      * Whether the buffer supports pausing
      */
-    virtual bool CanPauseStream() const
+    virtual bool CanPauseStream()
     {
       return false;
     }
@@ -115,6 +115,7 @@ namespace timeshift {
       return false;
     }
 
+
     /**
      * @return stream times
      */
@@ -142,6 +143,8 @@ namespace timeshift {
     {
       return time(nullptr);
     }
+
+    virtual void SetSid(char *sid) {}
 
     /**
      * Sets the read timeout (defaults to 10 seconds)

--- a/src/buffers/EpgBasedBuffer.cpp
+++ b/src/buffers/EpgBasedBuffer.cpp
@@ -1,0 +1,68 @@
+/*
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+*  MA 02110-1301  USA
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#include "EpgBasedBuffer.h"
+#include  "../BackendRequest.h"
+#include <thread>
+#include <mutex>
+
+#define HTTP_OK 200
+
+using namespace timeshift;
+
+/* EPG Based mode functions */
+
+bool EpgBasedBuffer::Open(const std::string inputUrl)
+{
+  struct PVR_RECORDING recording;
+  recording.recordingTime = time(nullptr);
+  recording.iDuration = 5 * 60 * 60;
+  m_sd.isPaused = false;
+  m_sd.lastPauseAdjust = 0;
+  XBMC->Log(LOG_DEBUG, "EpgBasedBuffer::Open In EPG Mode");
+  return RecordingBuffer::Open(inputUrl,recording);
+}
+
+bool EpgBasedBuffer::CanPauseStream()
+{
+  if (m_sd.isPaused == true)
+  {
+    time_t now = time(nullptr);
+    if ( m_sd.lastPauseAdjust + 10  >= now )
+    {
+      //m_sd.lastPauseAdjust = now + 10;
+			std::string response;
+      NextPVR::Request *request;
+      request = new NextPVR::Request();
+      std::this_thread::yield();
+      std::unique_lock<std::mutex> lock(m_mutex);
+			if (request->DoRequest("/service?method=channel.transcode.lease", response,m_sid) == HTTP_OK)
+			{
+				XBMC->Log(LOG_DEBUG, "channel.transcode.lease success");
+			}
+			else
+			{
+				XBMC->Log(LOG_ERROR, "channel.transcode.lease failed");
+			}
+      delete request;
+		}
+  }
+  return true;
+}

--- a/src/buffers/EpgBasedBuffer.h
+++ b/src/buffers/EpgBasedBuffer.h
@@ -1,0 +1,87 @@
+#pragma once
+/*
+*      Copyright (C) 2015 Sam Stenvall
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+*  MA 02110-1301  USA
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#include "RecordingBuffer.h"
+//#include <thread>
+//#include <condition_variable>
+#include <mutex>
+#include "session.h"
+
+using namespace ADDON;
+namespace timeshift {
+
+  /**
+   * Dummy buffer that just passes all calls through to the input file
+   * handle without actually buffering anything
+   */
+  class EpgBasedBuffer : public RecordingBuffer
+  {
+  private:
+    mutable std::mutex m_mutex;
+    session_data_t m_sd;
+    char m_sid[64];
+    //int NextPVR::DoRequest(const char *resource, std::string &response);
+
+  public:
+    EpgBasedBuffer() : RecordingBuffer() { XBMC->Log(LOG_NOTICE, "EPG Based Buffer created!");}
+
+    virtual ~EpgBasedBuffer() {}
+
+    virtual bool Open(const std::string inputUrl) override;
+
+    virtual bool CanPauseStream() override;
+
+    virtual void PauseStream(bool bPause) override
+    {
+      if ((m_sd.isPaused = bPause))
+        m_sd.lastPauseAdjust = m_sd.pauseStart = time(nullptr);
+      else
+        m_sd.lastPauseAdjust = m_sd.pauseStart = 0;
+    }
+    virtual bool IsTimeshifting() const override
+    {
+      XBMC->Log(LOG_DEBUG, "%s:%d: %lld %lld", __FUNCTION__, __LINE__, XBMC->GetFileLength(m_inputHandle) ,XBMC->GetFilePosition(m_inputHandle));
+      return true;
+    }
+
+    virtual bool IsRealTimeStream() const
+    {
+      return false;
+    }
+
+    /*virtual int64_t Length() const
+    {
+      return 0;
+      int64_t length;
+      if ( XBMC->GetFileLength(m_inputHandle) == 0 )
+      {
+          return XBMC->GetFilePosition(m_inputHandle);
+          NextPVR::DoRequest(NextPVR::af_inet, NextPVR::pf_inet, NextPVR::sock_stream, NextPVR::tcp)
+      }
+      return length;
+    }*/
+
+
+    void SetSid(char *sid) override { strcpy(m_sid,sid); }
+
+  };
+}

--- a/src/buffers/RecordingBuffer.cpp
+++ b/src/buffers/RecordingBuffer.cpp
@@ -29,7 +29,6 @@ PVR_ERROR RecordingBuffer::GetStreamTimes(PVR_STREAM_TIMES *stimes)
   stimes->ptsStart = 0;
   stimes->ptsBegin = 0;
   stimes->ptsEnd = ((int64_t ) Duration() ) * DVD_TIME_BASE;
-  XBMC->Log(LOG_DEBUG, "RecordingBuffer::GetStreamTimes called!");
   return PVR_ERROR_NO_ERROR;
 }
 
@@ -67,7 +66,39 @@ bool RecordingBuffer::Open(const std::string inputUrl,const PVR_RECORDING &recor
   {
     m_isRecording = false;
   }
-
+  if (recording.strDirectory)
+  {
+    struct  __stat64 StatFile;
+    char strDirectory [PVR_ADDON_URL_STRING_LENGTH];
+    strcpy(strDirectory,recording.strDirectory);
+    int i = 0;
+    int j = 0;
+  	for(; i <= strlen(recording.strDirectory); i++, j++)
+  	{
+      if (recording.strDirectory[i] == '\\')
+      {
+        if (i==0 && recording.strDirectory[1] == '\\')
+        {
+          strcpy(strDirectory,"smb://");
+          i = 1;
+          j = 5;
+        }
+        else
+        {
+          strDirectory[j] = '/';
+        }
+      }
+      else
+      {
+          strDirectory[j] = recording.strDirectory[i];
+      }
+	  }
+    if ( XBMC->StatFile(strDirectory,&StatFile) == 0)
+    {
+      XBMC->Log(LOG_DEBUG, "Native playback %s %lld", strDirectory, StatFile.st_size);
+      return Buffer::Open(std::string(strDirectory));
+    }
+  }
   return Buffer::Open(inputUrl);
 }
 

--- a/src/buffers/RecordingBuffer.h
+++ b/src/buffers/RecordingBuffer.h
@@ -47,7 +47,7 @@ namespace timeshift {
       return XBMC->SeekFile(m_inputHandle, position, whence);
     }
 
-    virtual bool CanPauseStream() const override
+    virtual bool CanPauseStream() override
     {
       return true;
     }

--- a/src/buffers/TimeshiftBuffer.h
+++ b/src/buffers/TimeshiftBuffer.h
@@ -52,7 +52,7 @@ namespace timeshift {
     virtual int Read(byte *buffer, size_t length) override;
     virtual int64_t Seek(int64_t position, int whence) override;
 
-    virtual bool CanPauseStream() const override
+    virtual bool CanPauseStream() override
     {
       return m_CanPause;
     }

--- a/src/client.h
+++ b/src/client.h
@@ -29,8 +29,9 @@
 
 enum eStreamingMethod
 {
-  TSReader = 0,
-  ffmpeg = 1
+  Timeshift = 0,
+  EPG_Based = 1,
+  Basic = 2
 };
 
 #define DEFAULT_HOST                  "127.0.0.1"
@@ -39,6 +40,7 @@ enum eStreamingMethod
 #define DEFAULT_RADIO                 true
 #define DEFAULT_USE_TIMESHIFT         false
 #define DEFAULT_GUIDE_ARTWORK         false
+#define DEFAULT_LIVE_STREAM           Timeshift
 
 extern std::string      g_szUserPath;         ///< The Path to the user directory inside user profile
 extern std::string      g_szClientPath;       ///< The Path where this driver is located
@@ -50,6 +52,7 @@ extern std::string      g_szPin;
 extern bool             g_bRadioEnabled;
 extern bool             g_bUseTimeshift;
 extern int16_t          g_timeShiftBufferSeconds;
+extern eStreamingMethod      g_livestreamingmethod;
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr          *PVR;

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -30,6 +30,7 @@
 #include "buffers/DummyBuffer.h"
 #include "buffers/TimeshiftBuffer.h"
 #include "buffers/RecordingBuffer.h"
+#include "buffers/EpgBasedBuffer.h"
 
 #define SAFE_DELETE(p)       do { delete (p);     (p)=NULL; } while (0)
 
@@ -184,5 +185,6 @@ private:
   time_t                  m_tsbStartTime;
   int                     m_timeShiftBufferSeconds;
   timeshift::Buffer      *m_timeshiftBuffer;
+  timeshift::Buffer      *m_radioBuffer;
   timeshift::RecordingBuffer *m_recordingBuffer;
 };


### PR DESCRIPTION
1. support for EPG Based live TV.   Seek looks to be broken maybe because NextPVR is not providing a Content-Length.  Worthwhile for longer pausing
2.  Recordings will play from file system for local files, shares, and using advancedsettings.xml subtitution.  
3. DoRequest moved to a Class so the buffer classes can use it.
4. Fixed radio playback in Timeshift mode, URL was not compatible with the new buffer
5. Debug log spam reduction in Recordings
