### PR TITLE
Delete recording trigger change,  cleanup initialization code

### DIFF
--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,8 +1,11 @@
 v3.3.14
-- Fixed issue with meta art not showing for deleted channels
-- New settings option to enabled Kodi style recordings - defaults to NextPVR style
+- Fixed issue with art not showing up on recordings from deleted channels
+- New settings option to enabled Kodi style recordings - defaults to NextPVR style (no title, with S/E )
 - Reduce channel tuning time in Extended Timeshift
-- Adjust for server time difference loading instant recordings
+- Removed trigger on deletes causing Kodi crash
+- Adjust for server time difference loading instant recordings (could show as scheduled)
+- Clean up MAC address logic, no WOL for localhost
+- Allow Kodi plugin:// URL in LiveStreams.xml
 
 v3.3.13
 - Add Extended Timeshift Rolling File based live tv and radio buffer (pause and seekable)

--- a/pvr.nextpvr/resources/settings.xml
+++ b/pvr.nextpvr/resources/settings.xml
@@ -10,7 +10,7 @@
   <!-- advanced -->
   <category label="30041">
     <setting id="usetimeshift" type="bool" label="30003" default="false" visible="false" />
-    <setting id="livestreamingmethod" type="enum" label="Live TV Stream" values="Timeshift|Extended Timeshift|Real Time" default="Real Time"/>
+    <setting id="livestreamingmethod" type="enum" label="Live TV Stream" values="Timeshift|Extended Timeshift|Real Time" default="2"/>
     <setting id="chunklivetv" label="30167" option="int" range="16,16,96" type="slider" default="64"  />
     <setting id="chunkrecording" label="30168" option="int" range="16,16,96" type="slider"  default="32"  />
     <setting id="prebuffer" label="30162" option="int" range="4,1,15" type="slider" visible="eq(-3,1)" default="8"  />

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -35,7 +35,7 @@ std::string      g_szHostname             = DEFAULT_HOST;                  ///< 
 std::string      g_szPin                  = DEFAULT_PIN;                   ///< The PIN for the NextPVR server
 int              g_iPort                  = DEFAULT_PORT;                  ///< The web listening port (default: 8866)
 int16_t          g_timeShiftBufferSeconds = 0;
-char             g_host_mac[18] = "\0";
+std::string      g_host_mac = "";
 eStreamingMethod g_livestreamingmethod = RealTime;
 eNowPlaying      g_NowPlaying = NotPlaying;
 int              g_wol_timeout;
@@ -214,7 +214,7 @@ void ADDON_ReadSettings(void)
 
   if (XBMC->GetSetting("host_mac", &buffer))
   {
-    snprintf(g_host_mac, sizeof(g_host_mac),"%s",buffer);
+    g_host_mac = buffer;
   }
 
   if (!XBMC->GetSetting("wolenable", &g_wol_enabled))
@@ -233,7 +233,7 @@ void ADDON_ReadSettings(void)
   }
 
   /* Log the current settings for debugging purposes */
-  XBMC->Log(LOG_DEBUG, "settings: host='%s', port=%i, mac=%4.4s...", g_szHostname.c_str(), g_iPort, g_host_mac);
+  XBMC->Log(LOG_DEBUG, "settings: host='%s', port=%i, mac=%4.4s...", g_szHostname.c_str(), g_iPort, g_host_mac.c_str());
 
 }
 
@@ -318,10 +318,10 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
   }
   else if (str == "host_mac")
   {
-    if (strcmp ( g_host_mac, (const char *)settingValue ))
+    if ( g_host_mac != (const char *)settingValue )
     {
-      XBMC->Log(LOG_INFO, "Changed setting 'host_mac' from %4.4s... to %4.4s...", g_host_mac, (const char *)settingValue );
-      strcpy (g_host_mac, (const char *) settingValue);
+      XBMC->Log(LOG_INFO, "Changed setting 'host_mac' from %4.4s... to %4.4s...", g_host_mac.c_str(), (const char *)settingValue );
+      g_host_mac = (const char *) settingValue;
       return ADDON_STATUS_OK ;
     }
   }
@@ -661,6 +661,13 @@ PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
     return g_client->SignalStatus(signalStatus);
 }
 
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
+{
+  if (g_client)
+    return g_client->GetChannelStreamProperties(*channel,properties,iPropertiesCount);
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 /*******************************************/
 /** PVR Recording Stream Functions        **/
 
@@ -786,7 +793,6 @@ PVR_ERROR DeleteAllRecordingsFromTrash() { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*)  { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR IsEPGTagRecordable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR IsEPGTagPlayable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/src/client.h
+++ b/src/client.h
@@ -57,7 +57,7 @@ extern std::string      g_szClientPath;       ///< The Path where this driver is
 extern std::string      g_szHostname;
 extern int              g_iPort;
 extern std::string      g_szPin;
-extern char             g_host_mac[18];
+extern std::string      g_host_mac;
 extern int              g_wol_timeout;
 extern bool             g_wol_enabled;
 extern bool             g_bRadioEnabled;

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -101,6 +101,8 @@ public:
   /* Channel handling */
   int GetNumChannels(void);
   PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
+  PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL &channel, PVR_NAMED_VALUE *properties, unsigned int *iPropertiesCount);
+  bool IsChannelAPlugin(int uid);
 
   /* Channel group handling */
   int GetChannelGroupsAmount(void);


### PR DESCRIPTION
Removed unnecessary trigger  after deleting a recording,  prevent delete of in progress recording, clean up error message.  Added playback of plugin:/ URLs.  Cleaned up MAC address logic and skip WOL for localhost.  Fixed default for settings.xml