### PR TITLE
CreateThread change

### DIFF
--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -6,6 +6,7 @@ v3.3.14
 - Adjust for server time difference loading instant recordings (could show as scheduled)
 - Clean up MAC address logic, no WOL for localhost
 - Allow Kodi plugin:// URL in LiveStreams.xml
+- CreateThread() change
 
 v3.3.13
 - Add Extended Timeshift Rolling File based live tv and radio buffer (pause and seekable)

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -159,7 +159,7 @@ cPVRClientNextPVR::cPVRClientNextPVR()
   m_realTimeBuffer = new timeshift::DummyBuffer();
   m_livePlayer = nullptr;
 
-  CreateThread(false);
+  CreateThread();
 }
 
 cPVRClientNextPVR::~cPVRClientNextPVR()


### PR DESCRIPTION
CreateThread was not waiting for thread to be created in constructor.  Could crash if descructor called quickly after connection failure.