### PR TITLE
[Matrix] fix LICENSE name and fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)
 
 # NextPVR PVR
-NextPVR PVR client addon for [Kodi] (https://kodi.tv)
+NextPVR PVR client addon for [Kodi](https://kodi.tv)
 
 ## Build instructions
 
@@ -19,5 +19,5 @@ NextPVR PVR client addon for [Kodi] (https://kodi.tv)
 
 ##### Useful links
 
-* [Kodi's PVR user support] (https://forum.kodi.tv/forumdisplay.php?fid=167)
-* [Kodi's PVR development support] (https://forum.kodi.tv/forumdisplay.php?fid=136)
+* [Kodi's PVR user support](https://forum.kodi.tv/forumdisplay.php?fid=167)
+* [Kodi's PVR development support](https://forum.kodi.tv/forumdisplay.php?fid=136)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![License: GPL v2+](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
+[![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
 [![Build Status](https://travis-ci.org/kodi-pvr/pvr.nextpvr.svg?branch=Matrix)](https://travis-ci.org/kodi-pvr/pvr.nextpvr/branches)
 [![Build Status](https://dev.azure.com/teamkodi/kodi-pvr/_apis/build/status/kodi-pvr.pvr.nextpvr?branchName=Matrix)](https://dev.azure.com/teamkodi/kodi-pvr/_build/latest?definitionId=64&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/kodi-pvr/job/pvr.nextpvr/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-pvr%2Fpvr.nextpvr/branches/)

--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -169,7 +169,7 @@
     <disclaimer lang="zh_CN">此插件仍在开发中，请自行把握试用风险。</disclaimer>
     <disclaimer lang="zh_TW">這個程式尚在開發中。使用上您須自行考慮到可能有的風險。</disclaimer>
     <platform>@PLATFORM@</platform>
-    <license>GPL-2.0</license>
+    <license>GPL-2.0-or-later</license>
     <source>https://github.com/kodi-pvr/pvr.nextpvr</source>
     <forum>https://forum.kodi.tv/forumdisplay.php?fid=175</forum>
     <assets>

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -6,7 +6,7 @@ v4.3.4
 - Update with some minor cleanups
 - Cleanup source copyright to match SPDX
 - Add license name, forum url and source url to addon.xml
-- Add GPL2 license file and show GPL2 on README.md
+- Add GPL2 license file and show GPL-2.0-or-later on README.md
 
 v4.3.3
 - Update PVR API 6.2.0 - strFirstAired and EPG New flag


### PR DESCRIPTION
About the note somewhere before with GPL2+ on addon.xml was wrong.
It need `<license>GPL-2.0-or-later</license>` see https://kodi.wiki/view/Addon.xml