### PR TITLE
Code Restructuring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,11 @@ set(NEXTPVR_SOURCES src/client.cpp
                     src/Socket.cpp
                     src/uri.cpp
                     src/BackendRequest.cpp
+                    src/Channels.cpp
+                    src/EPG.cpp
+                    src/Recordings.cpp
                     src/Settings.cpp
+                    src/Timers.cpp
                     src/buffers/Buffer.cpp
                     src/buffers/DummyBuffer.cpp
                     src/buffers/TranscodedBuffer.cpp
@@ -38,7 +42,11 @@ set(NEXTPVR_HEADERS src/client.h
                     src/Socket.h
                     src/uri.h
                     src/BackendRequest.h
+                    src/Channels.h
+                    src/EPG.h
+                    src/Recordings.h
                     src/Settings.h
+                    src/Timers.h
                     src/buffers/Buffer.h
                     src/buffers/DummyBuffer.h
                     src/buffers/TranscodedBuffer.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(NEXTPVR_SOURCES src/client.cpp
                     src/BackendRequest.cpp
                     src/Channels.cpp
                     src/EPG.cpp
+                    src/MenuHook.cpp
                     src/Recordings.cpp
                     src/Settings.cpp
                     src/Timers.cpp
@@ -44,6 +45,7 @@ set(NEXTPVR_HEADERS src/client.h
                     src/BackendRequest.h
                     src/Channels.h
                     src/EPG.h
+                    src/MenuHook.h
                     src/Recordings.h
                     src/Settings.h
                     src/Timers.h

--- a/src/BackendRequest.cpp
+++ b/src/BackendRequest.cpp
@@ -6,7 +6,8 @@
  *  See LICENSE.md for more information.
  */
 
-#include  "BackendRequest.h"
+#include "BackendRequest.h"
+
 #include "Socket.h"
 #include <libKODI_guilib.h>
 #include <p8-platform/util/StringUtils.h>
@@ -15,21 +16,21 @@ using namespace ADDON;
 
 namespace NextPVR
 {
-  int Request::DoRequest(const char *resource, std::string &response)
+  int Request::DoRequest(const char* resource, std::string& response)
   {
     P8PLATFORM::CLockObject lock(m_mutexRequest);
     m_start = time(nullptr);
     // build request string, adding SID if requred
-    char strURL[1024];
+    std::string URL;
 
     if (strstr(resource, "method=session") == NULL)
-      snprintf(strURL,sizeof(strURL),"http://%s:%d%s&sid=%s", m_settings.m_hostname.c_str(), m_settings.m_port, resource, m_sid);
+      URL = StringUtils::Format("http://%s:%d%s&sid=%s", m_settings.m_hostname.c_str(), m_settings.m_port, resource, m_sid);
     else
-      snprintf(strURL,sizeof(strURL),"http://%s:%d%s", m_settings.m_hostname.c_str(), m_settings.m_port, resource);
+      URL = StringUtils::Format("http://%s:%d%s", m_settings.m_hostname.c_str(), m_settings.m_port, resource);
 
     // ask XBMC to read the URL for us
     int resultCode = HTTP_NOTFOUND;
-    void* fileHandle = XBMC->OpenFile(strURL, READ_NO_CACHE);
+    void* fileHandle = XBMC->OpenFile(URL.c_str(), READ_NO_CACHE);
     if (fileHandle)
     {
       char buffer[1024];
@@ -39,37 +40,37 @@ namespace NextPVR
       }
       XBMC->CloseFile(fileHandle);
       resultCode = HTTP_OK;
-      if ((response.empty() || strstr(response.c_str(), "<rsp stat=\"ok\">") == NULL) && strstr(resource, "method=channel.stream.info") == NULL )
+      if ((response.empty() || strstr(response.c_str(), "<rsp stat=\"ok\">") == NULL) && strstr(resource, "method=channel.stream.info") == NULL)
       {
         XBMC->Log(LOG_ERROR, "DoRequest failed, response=%s", response.c_str());
         resultCode = HTTP_BADREQUEST;
       }
     }
-    XBMC->Log(LOG_DEBUG, "DoRequest return %s %d %d %d", resource, resultCode,response.length(),time(nullptr) -m_start);
+    XBMC->Log(LOG_DEBUG, "DoRequest return %s %d %d %d", resource, resultCode, response.length(), time(nullptr) - m_start);
 
     return resultCode;
   }
-  int Request::FileCopy(const char *resource,std::string fileName)
+  int Request::FileCopy(const char* resource, std::string fileName)
   {
     P8PLATFORM::CLockObject lock(m_mutexRequest);
-    int written = 0;
+    ssize_t written = 0;
     m_start = time(nullptr);
 
-    char strURL[1024];
-    char separator = (strchr(resource,'?') == nullptr) ?  '?' : '&';
-    snprintf(strURL,sizeof(strURL),"http://%s:%d%s%csid=%s", m_settings.m_hostname.c_str(), m_settings.m_port, resource, separator, m_sid);
+
+    char separator = (strchr(resource, '?') == nullptr) ? '?' : '&';
+    const std::string URL = StringUtils::Format("http://%s:%d%s%csid=%s", m_settings.m_hostname.c_str(), m_settings.m_port, resource, separator, m_sid);
 
     // ask XBMC to read the URL for us
     int resultCode = HTTP_NOTFOUND;
-    void* inputFile = XBMC->OpenFile(strURL, READ_NO_CACHE);
-    int datalen;
+    void* inputFile = XBMC->OpenFile(URL.c_str(), READ_NO_CACHE);
+    ssize_t datalen;
     if (inputFile)
     {
       void* outputFile = XBMC->OpenFileForWrite(fileName.c_str(), true);
       if (outputFile)
       {
         char buffer[1024];
-        while ((datalen=XBMC->ReadFile(inputFile, buffer, sizeof(buffer))))
+        while ((datalen = XBMC->ReadFile(inputFile, buffer, sizeof(buffer))))
         {
           XBMC->WriteFile(outputFile, buffer, datalen);
           written += datalen;
@@ -83,15 +84,14 @@ namespace NextPVR
     {
       resultCode = HTTP_BADREQUEST;
     }
-    XBMC->Log(LOG_DEBUG, "FileCopy (%s - %s) %d %d %d", resource, fileName.c_str(), resultCode,written,time(nullptr) -m_start);
+    XBMC->Log(LOG_DEBUG, "FileCopy (%s - %s) %zu %d %d", resource, fileName.c_str(), resultCode, written, time(nullptr) - m_start);
 
     return resultCode;
   }
   bool Request::PingBackend()
   {
-    char strURL[1024];
-    snprintf(strURL,sizeof(strURL),"http://%s:%d%s|connection-timeout=2", m_settings.m_hostname.c_str(), m_settings.m_port, "/service?method=recording.lastupdated");
-    void* fileHandle = XBMC->OpenFile(strURL, READ_NO_CACHE);
+    const std::string URL = StringUtils::Format("http://%s:%d%s|connection-timeout=2", m_settings.m_hostname.c_str(), m_settings.m_port, "/service?method=recording.lastupdated");
+    void* fileHandle = XBMC->OpenFile(URL.c_str(), READ_NO_CACHE);
     if (fileHandle)
     {
       XBMC->CloseFile(fileHandle);
@@ -99,12 +99,12 @@ namespace NextPVR
     }
     return false;
   }
-  bool Request::OneTimeSetup(void *hdl)
+  bool Request::OneTimeSetup(void* hdl)
   {
-    // create user folder for channel icons and try and locate backend
-    #if defined(TARGET_WINDOWS)
-      #undef CreateDirectory
-    #endif
+// create user folder for channel icons and try and locate backend
+#if defined(TARGET_WINDOWS)
+#undef CreateDirectory
+#endif
     const std::string backend = "http://127.0.0.1:8866/service?method=recording.lastupdated|connection-timeout=2";
     void* fileHandle = XBMC->OpenFile(backend.c_str(), READ_NO_CACHE);
     if (fileHandle)
@@ -136,21 +136,21 @@ namespace NextPVR
           delete GUI;
           if (offset < 0)
           {
-            XBMC->Log(LOG_INFO,"User canceled setup expect a failed install");
+            XBMC->Log(LOG_INFO, "User canceled setup expect a failed install");
             return false;
           }
         }
         XBMC->CreateDirectory("special://userdata/addon_data/pvr.nextpvr/");
         m_settings.UpdateServerPort(foundAddress[offset][0], std::stoi(foundAddress[offset][1]));
         XBMC->QueueNotification(QUEUE_INFO, XBMC->GetLocalizedString(30182), m_settings.m_hostname.c_str(), m_settings.m_port);
-        char *settings = XBMC->TranslateSpecialProtocol("special://profile/addon_data/pvr.nextpvr/settings.xml");
+        char* settings = XBMC->TranslateSpecialProtocol("special://profile/addon_data/pvr.nextpvr/settings.xml");
         // create settings.xml with host and port
-        void* settingsFile = XBMC->OpenFileForWrite(settings,false);
+        void* settingsFile = XBMC->OpenFileForWrite(settings, false);
         const char tmp[] = "<settings version=\"2\">\n</settings>\n";
-        XBMC->WriteFile(settingsFile,tmp, strlen(tmp));
+        XBMC->WriteFile(settingsFile, tmp, strlen(tmp));
         XBMC->CloseFile(settingsFile);
-        m_settings.SaveSettings("host",m_settings.m_hostname);
-        m_settings.SaveSettings("port",std::to_string(m_settings.m_port));
+        m_settings.SaveSettings("host", m_settings.m_hostname);
+        m_settings.SaveSettings("port", std::to_string(m_settings.m_port));
         XBMC->FreeString(settings);
         return true;
       }
@@ -178,7 +178,7 @@ namespace NextPVR
       struct timeval tv;
       tv.tv_sec = 5;
       tv.tv_usec = 0;
-      if (optResult = socket->SetSocketOption( SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char*>(&tv), sizeof(tv)))
+      if (optResult = socket->SetSocketOption(SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char*>(&tv), sizeof(tv)))
         XBMC->Log(LOG_ERROR, "SO_RCVTIMEO %d", optResult);
 #endif
 
@@ -186,8 +186,9 @@ namespace NextPVR
       if (socket->BroadcastSendTo(16891, msg, sizeof(msg)) > 0)
       {
         int sockResult;
-        do {
-          char response[512]{ 0 };
+        do
+        {
+          char response[512]{0};
           if (sockResult = socket->BroadcastReceiveFrom(response, 512) > 0)
           {
             std::vector<std::string> parseResponse = StringUtils::Split(response, ":");
@@ -203,4 +204,4 @@ namespace NextPVR
     socket->close();
     return foundAddress;
   }
-}
+} // namespace NextPVR

--- a/src/BackendRequest.cpp
+++ b/src/BackendRequest.cpp
@@ -23,7 +23,7 @@ namespace NextPVR
     // build request string, adding SID if requred
     std::string URL;
 
-    if (strstr(resource, "method=session") == NULL)
+    if (strstr(resource, "method=session") == nullptr)
       URL = StringUtils::Format("http://%s:%d%s&sid=%s", m_settings.m_hostname.c_str(), m_settings.m_port, resource, m_sid);
     else
       URL = StringUtils::Format("http://%s:%d%s", m_settings.m_hostname.c_str(), m_settings.m_port, resource);
@@ -40,7 +40,7 @@ namespace NextPVR
       }
       XBMC->CloseFile(fileHandle);
       resultCode = HTTP_OK;
-      if ((response.empty() || strstr(response.c_str(), "<rsp stat=\"ok\">") == NULL) && strstr(resource, "method=channel.stream.info") == NULL)
+      if ((response.empty() || strstr(response.c_str(), "<rsp stat=\"ok\">") == nullptr) && strstr(resource, "method=channel.stream.info") == nullptr)
       {
         XBMC->Log(LOG_ERROR, "DoRequest failed, response=%s", response.c_str());
         resultCode = HTTP_BADREQUEST;
@@ -66,7 +66,7 @@ namespace NextPVR
     ssize_t datalen;
     if (inputFile)
     {
-      void* outputFile = XBMC->OpenFileForWrite(fileName.c_str(), true);
+      void* outputFile = XBMC->OpenFileForWrite(fileName.c_str(), READ_NO_CACHE);
       if (outputFile)
       {
         char buffer[1024];
@@ -145,7 +145,7 @@ namespace NextPVR
         XBMC->QueueNotification(QUEUE_INFO, XBMC->GetLocalizedString(30182), m_settings.m_hostname.c_str(), m_settings.m_port);
         char* settings = XBMC->TranslateSpecialProtocol("special://profile/addon_data/pvr.nextpvr/settings.xml");
         // create settings.xml with host and port
-        void* settingsFile = XBMC->OpenFileForWrite(settings, false);
+        void* settingsFile = XBMC->OpenFileForWrite(settings, READ_NO_CACHE);
         const char tmp[] = "<settings version=\"2\">\n</settings>\n";
         XBMC->WriteFile(settingsFile, tmp, strlen(tmp));
         XBMC->CloseFile(settingsFile);

--- a/src/BackendRequest.h
+++ b/src/BackendRequest.h
@@ -10,10 +10,11 @@
 
 #include "Settings.h"
 #include "client.h"
+#include "p8-platform/threads/mutex.h"
+
 #include <ctime>
 #include <stdio.h>
 #include <stdlib.h>
-#include "p8-platform/threads/mutex.h"
 
 #define HTTP_OK 200
 #define HTTP_NOTFOUND 404
@@ -25,31 +26,32 @@ namespace NextPVR
 {
   class Request
   {
-    public:
-      /*
+  public:
+    /*
       * Singleton getter for the instance
       */
-      static Request& GetInstance()
-      {
-        static Request request;
-        return request;
-      }
-      int DoRequest(const char *resource, std::string &response);
-      int FileCopy(const char *resource, std::string fileName);
-      void setSID(char *newsid) {strcpy(m_sid,newsid);};
-      bool PingBackend();
-      bool OneTimeSetup(void *hdl);
-      const char *getSID() {return m_sid;};
-      std::vector<std::vector<std::string>> Discovery();
-    private:
-      Request() = default;
+    static Request& GetInstance()
+    {
+      static Request request;
+      return request;
+    }
+    int DoRequest(const char* resource, std::string& response);
+    int FileCopy(const char* resource, std::string fileName);
+    void setSID(char* newsid) { strcpy(m_sid, newsid); };
+    bool PingBackend();
+    bool OneTimeSetup(void* hdl);
+    const char* getSID() { return m_sid; };
+    std::vector<std::vector<std::string>> Discovery();
 
-      Request(Request const&) = delete;
-      void operator=(Request const&) = delete;
+  private:
+    Request() = default;
 
-      Settings& m_settings = Settings::GetInstance();
-      P8PLATFORM::CMutex m_mutexRequest;
-      time_t m_start = 0;
-      char m_sid[64]{0};
+    Request(Request const&) = delete;
+    void operator=(Request const&) = delete;
+
+    Settings& m_settings = Settings::GetInstance();
+    P8PLATFORM::CMutex m_mutexRequest;
+    time_t m_start = 0;
+    char m_sid[64]{0};
   };
-}
+} // namespace NextPVR

--- a/src/Channels.cpp
+++ b/src/Channels.cpp
@@ -20,7 +20,6 @@ using namespace NextPVR;
 
 int Channels::GetNumChannels(void)
 {
-  LOG_API_CALL(__FUNCTION__);
   // need something more optimal, but this will do for now...
   std::string response;
   int channelCount = 0;
@@ -43,8 +42,6 @@ int Channels::GetNumChannels(void)
 
 std::string Channels::GetChannelIcon(int channelID)
 {
-  LOG_API_CALL(__FUNCTION__);
-
   std::string iconFilename = GetChannelIconFileName(channelID);
 
   // do we already have the icon file?
@@ -94,8 +91,6 @@ PVR_ERROR Channels::GetChannels(ADDON_HANDLE handle, bool bRadio)
 {
   PVR_CHANNEL     tag;
   std::string      stream;
-  LOG_API_CALL(__FUNCTION__);
-
   std::map<int, std::pair<bool, bool>>::iterator  itr = m_channelDetails.begin();
   while (itr != m_channelDetails.end())
   {
@@ -170,12 +165,7 @@ PVR_ERROR Channels::GetChannels(ADDON_HANDLE handle, bool bRadio)
 
 int Channels::GetChannelGroupsAmount(void)
 {
-  LOG_API_CALL(__FUNCTION__);
-  // Not directly possible at the moment
-  XBMC->Log(LOG_DEBUG, "GetChannelGroupsAmount");
-
   int groups = 0;
-
   std::string response;
   if (m_request.DoRequest("/service?method=channel.groups", response) == HTTP_OK)
   {
@@ -206,8 +196,6 @@ PVR_RECORDING_CHANNEL_TYPE Channels::GetChannelType(unsigned int uid)
 PVR_ERROR Channels::GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
 {
   PVR_CHANNEL_GROUP tag;
-  LOG_API_CALL(__FUNCTION__);
-
   // nextpvr doesn't have a separate concept of radio channel groups
   if (bRadio)
     return PVR_ERROR_NO_ERROR;
@@ -251,8 +239,6 @@ PVR_ERROR Channels::GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
 PVR_ERROR Channels::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
 {
   std::string encodedGroupName = UriEncode(group.strGroupName);
-  LOG_API_CALL(__FUNCTION__);
-
   std::string request = "/service?method=channel.list&group_id=" + encodedGroupName;
   std::string response;
   if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)

--- a/src/Channels.cpp
+++ b/src/Channels.cpp
@@ -1,0 +1,338 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "Channels.h"
+
+#include "kodi/util/XMLUtils.h"
+
+#include "pvrclient-nextpvr.h"
+
+#include <p8-platform/util/StringUtils.h>
+
+#if defined(TARGET_WINDOWS)
+#define atoll(S) _atoi64(S)
+#else
+#define MAXINT64 ULONG_MAX
+#endif
+
+using namespace NextPVR;
+
+/** Channel handling */
+
+int Channels::GetNumChannels(void)
+{
+  LOG_API_CALL(__FUNCTION__);
+  // need something more optimal, but this will do for now...
+  std::string response;
+  int channelCount = 0;
+  if (m_request.DoRequest("/service?method=channel.list", response) == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()) != NULL)
+    {
+      TiXmlElement* channelsNode = doc.RootElement()->FirstChildElement("channels");
+      TiXmlElement* pChannelNode;
+      for( pChannelNode = channelsNode->FirstChildElement("channel"); pChannelNode; pChannelNode=pChannelNode->NextSiblingElement())
+      {
+        channelCount++;
+      }
+    }
+  }
+
+  return channelCount;
+}
+
+std::string Channels::GetChannelIcon(int channelID)
+{
+  LOG_API_CALL(__FUNCTION__);
+
+  std::string iconFilename = GetChannelIconFileName(channelID);
+
+  // do we already have the icon file?
+  if (XBMC->FileExists(XBMC->TranslateSpecialProtocol(iconFilename.c_str()), false))
+  {
+    return iconFilename;
+  }
+  const std::string URL = "/service?method=channel.icon&channel_id=" + std::to_string(channelID);
+  if (m_request.FileCopy(URL.c_str(), iconFilename) == HTTP_OK)
+  {
+    return iconFilename;
+  }
+
+  return "";
+}
+
+std::string Channels::GetChannelIconFileName(int channelID)
+{
+  return StringUtils::Format("special://userdata/addon_data/pvr.nextpvr/nextpvr-ch%d.png",channelID);
+}
+
+void  Channels::DeleteChannelIcon(int channelID)
+{
+  #if defined(TARGET_WINDOWS)
+    #undef DeleteFile
+  #endif
+  XBMC->DeleteFile(GetChannelIconFileName(channelID).c_str());
+}
+
+void  Channels::DeleteChannelIcons()
+{
+  VFSDirEntry* icons;
+  unsigned int count;
+  if (XBMC->GetDirectory("special://userdata/addon_data/pvr.nextpvr/","nextpvr-ch*.png", &icons, &count))
+  {
+    XBMC->Log(LOG_INFO, "Deleting %d channel icons", count);
+    for (unsigned int i = 0; i < count; ++i)
+    {
+      VFSDirEntry& f = icons[i];
+      const std::string deleteme = f.path;
+      XBMC->Log(LOG_DEBUG,"DeleteFile %s rc:%d",XBMC->TranslateSpecialProtocol(f.path),remove(XBMC->TranslateSpecialProtocol(f.path)));
+    }
+  }
+}
+
+PVR_ERROR Channels::GetChannels(ADDON_HANDLE handle, bool bRadio)
+{
+  PVR_CHANNEL     tag;
+  std::string      stream;
+  LOG_API_CALL(__FUNCTION__);
+
+  std::map<int, std::pair<bool, bool>>::iterator  itr = m_channelDetails.begin();
+  while (itr != m_channelDetails.end())
+  {
+    if (itr->second.second == (bRadio == true))
+      itr = m_channelDetails.erase(itr);
+    else
+      ++itr;
+  }
+
+  std::string response;
+  if (m_request.DoRequest("/service?method=channel.list&extras=true", response) == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()) != NULL)
+    {
+      TiXmlElement* channelsNode = doc.RootElement()->FirstChildElement("channels");
+      TiXmlElement* pChannelNode;
+      for( pChannelNode = channelsNode->FirstChildElement("channel"); pChannelNode; pChannelNode=pChannelNode->NextSiblingElement())
+      {
+        tag = {0};
+        tag.iUniqueId = g_pvrclient->XmlGetUInt(pChannelNode, "id");
+        std::string buffer;
+        XMLUtils::GetString(pChannelNode,"type",buffer);
+        if ( buffer =="0xa")
+        {
+          tag.bIsRadio = true;
+          strcpy(tag.strInputFormat, "application/octet-stream");
+        }
+        else
+        {
+          tag.bIsRadio = false;
+          if (IsChannelAPlugin(tag.iUniqueId))
+            strcpy(tag.strInputFormat, "video/MP2T");
+        }
+        if (bRadio != tag.bIsRadio)
+          continue;
+
+        tag.iChannelNumber = g_pvrclient->XmlGetUInt(pChannelNode, "number");
+        tag.iSubChannelNumber = g_pvrclient->XmlGetUInt(pChannelNode, "minor");
+
+        buffer.clear();
+        XMLUtils::GetString(pChannelNode,"name",buffer);
+        buffer.copy(tag.strChannelName,sizeof(tag.strChannelName)-1);
+
+        // check if we need to download a channel icon
+        bool isIcon;
+        if (XMLUtils::GetBoolean(pChannelNode,"icon",isIcon))
+        {
+          // only set when true;
+          std::string iconFile = GetChannelIcon(tag.iUniqueId);
+          if (iconFile.length() > 0)
+            iconFile.copy(tag.strIconPath,sizeof(tag.strIconPath)-1);
+        }
+
+        // V5 has the EPG source type info.
+        std::string epg;
+        if (XMLUtils::GetString(pChannelNode, "epg", epg))
+          m_channelDetails[tag.iUniqueId] = std::make_pair(epg == "None", tag.bIsRadio);
+        else
+          m_channelDetails[tag.iUniqueId] = std::make_pair(false, tag.bIsRadio);
+
+        // transfer channel to XBMC
+        PVR->TransferChannelEntry(handle, &tag);
+      }
+    }
+  }
+  return PVR_ERROR_NO_ERROR;
+}
+
+/************************************************************/
+/** Channel group handling **/
+
+int Channels::GetChannelGroupsAmount(void)
+{
+  LOG_API_CALL(__FUNCTION__);
+  // Not directly possible at the moment
+  XBMC->Log(LOG_DEBUG, "GetChannelGroupsAmount");
+
+  int groups = 0;
+
+  std::string response;
+  if (m_request.DoRequest("/service?method=channel.groups", response) == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()) != NULL)
+    {
+      TiXmlElement* groupsNode = doc.RootElement()->FirstChildElement("groups");
+      TiXmlElement* pGroupNode;
+      for( pGroupNode = groupsNode->FirstChildElement("group"); pGroupNode; pGroupNode=pGroupNode->NextSiblingElement())
+      {
+        groups++;
+      }
+    }
+  }
+
+  return groups;
+}
+
+PVR_RECORDING_CHANNEL_TYPE Channels::GetChannelType(unsigned int uid)
+{
+  // when uid is invalid we assume TV because Kodi will
+  if (m_channelDetails.count(uid) > 0 && m_channelDetails[uid].second == true)
+    return PVR_RECORDING_CHANNEL_TYPE_RADIO;
+
+  return PVR_RECORDING_CHANNEL_TYPE_TV;
+}
+
+PVR_ERROR Channels::GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
+{
+  PVR_CHANNEL_GROUP tag;
+  LOG_API_CALL(__FUNCTION__);
+
+  // nextpvr doesn't have a separate concept of radio channel groups
+  if (bRadio)
+    return PVR_ERROR_NO_ERROR;
+
+  // for tv, use the groups returned by nextpvr
+  std::string response;
+  if (m_request.DoRequest("/service?method=channel.groups", response) == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()) != NULL)
+    {
+      TiXmlElement* groupsNode = doc.RootElement()->FirstChildElement("groups");
+      TiXmlElement* pGroupNode;
+      for( pGroupNode = groupsNode->FirstChildElement("group"); pGroupNode; pGroupNode=pGroupNode->NextSiblingElement())
+      {
+        tag = {0};
+        tag.bIsRadio  = false;
+        tag.iPosition = 0; // groups default order, unused
+        std::string group;
+        if ( XMLUtils::GetString(pGroupNode,"name",group) )
+        {
+          // tell XBMC about channel, ignoring "All Channels" since xbmc has an built in group with effectively the same function
+          strcpy(tag.strGroupName,group.c_str());
+          if (strcmp(tag.strGroupName, "All Channels") != 0 && tag.strGroupName[0]!=0)
+          {
+            PVR->TransferChannelGroup(handle, &tag);
+          }
+        }
+      }
+    }
+    else
+    {
+      XBMC->Log(LOG_DEBUG, "GetChannelGroupsAmount");
+    }
+
+  }
+  return PVR_ERROR_NO_ERROR;
+}
+
+
+PVR_ERROR Channels::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
+{
+  std::string encodedGroupName = UriEncode(group.strGroupName);
+  LOG_API_CALL(__FUNCTION__);
+
+  std::string request = "/service?method=channel.list&group_id=" + encodedGroupName;
+  std::string response;
+  if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
+  {
+    PVR_CHANNEL_GROUP_MEMBER tag;
+
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()) != NULL)
+    {
+      TiXmlElement* channelsNode = doc.RootElement()->FirstChildElement("channels");
+      TiXmlElement* pChannelNode;
+      for( pChannelNode = channelsNode->FirstChildElement("channel"); pChannelNode; pChannelNode=pChannelNode->NextSiblingElement())
+      {
+        tag = {0};
+        strcpy(tag.strGroupName, group.strGroupName);
+        tag.iChannelNumber = g_pvrclient->XmlGetUInt(pChannelNode, "id");
+        tag.iChannelNumber = g_pvrclient->XmlGetUInt(pChannelNode, "number");
+        tag.iSubChannelNumber = g_pvrclient->XmlGetUInt(pChannelNode, "minor");
+        ;
+        PVR->TransferChannelGroupMember(handle, &tag);
+      }
+    }
+  }
+
+  return PVR_ERROR_NO_ERROR;
+}
+
+bool Channels::IsChannelAPlugin(int uid)
+{
+  if (m_liveStreams.count(uid) != 0)
+    if (StringUtils::StartsWith(m_liveStreams[uid], "plugin:") || StringUtils::EndsWithNoCase(m_liveStreams[uid], ".m3u8"))
+      return true;
+
+  return false;
+}
+
+/************************************************************/
+void Channels::LoadLiveStreams()
+{
+  const std::string URL = "/public/LiveStreams.xml";
+  m_liveStreams.clear();
+  if (m_request.FileCopy(URL.c_str(), "special://userdata/addon_data/pvr.nextpvr/LiveStreams.xml") == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    char* liveStreams = XBMC->TranslateSpecialProtocol("special://userdata/addon_data/pvr.nextpvr/LiveStreams.xml");
+    XBMC->Log(LOG_DEBUG, "Loading LiveStreams.xml %s", liveStreams);
+    if (doc.LoadFile(liveStreams))
+    {
+      TiXmlElement* streamsNode = doc.FirstChildElement("streams");
+      if (streamsNode)
+      {
+        TiXmlElement* streamNode;
+        for (streamNode = streamsNode->FirstChildElement("stream"); streamNode; streamNode = streamNode->NextSiblingElement())
+        {
+          std::string key_value;
+          if (streamNode->QueryStringAttribute("id", &key_value) == TIXML_SUCCESS)
+          {
+            try
+            {
+              if (streamNode->FirstChild())
+              {
+                int channelID = std::stoi(key_value);
+                XBMC->Log(LOG_DEBUG, "%d %s", channelID, streamNode->FirstChild()->Value());
+                m_liveStreams[channelID] = streamNode->FirstChild()->Value();
+              }
+            }
+            catch (...)
+            {
+              XBMC->Log(LOG_DEBUG, "%s:%d", __FUNCTION__, __LINE__);
+            }
+          }
+        }
+      }
+      XBMC->FreeString(liveStreams);
+    }
+  }
+}

--- a/src/Channels.cpp
+++ b/src/Channels.cpp
@@ -14,12 +14,6 @@
 
 #include <p8-platform/util/StringUtils.h>
 
-#if defined(TARGET_WINDOWS)
-#define atoll(S) _atoi64(S)
-#else
-#define MAXINT64 ULONG_MAX
-#endif
-
 using namespace NextPVR;
 
 /** Channel handling */
@@ -33,7 +27,7 @@ int Channels::GetNumChannels(void)
   if (m_request.DoRequest("/service?method=channel.list", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       TiXmlElement* channelsNode = doc.RootElement()->FirstChildElement("channels");
       TiXmlElement* pChannelNode;
@@ -115,7 +109,7 @@ PVR_ERROR Channels::GetChannels(ADDON_HANDLE handle, bool bRadio)
   if (m_request.DoRequest("/service?method=channel.list&extras=true", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       TiXmlElement* channelsNode = doc.RootElement()->FirstChildElement("channels");
       TiXmlElement* pChannelNode;
@@ -186,7 +180,7 @@ int Channels::GetChannelGroupsAmount(void)
   if (m_request.DoRequest("/service?method=channel.groups", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       TiXmlElement* groupsNode = doc.RootElement()->FirstChildElement("groups");
       TiXmlElement* pGroupNode;
@@ -223,7 +217,7 @@ PVR_ERROR Channels::GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
   if (m_request.DoRequest("/service?method=channel.groups", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       TiXmlElement* groupsNode = doc.RootElement()->FirstChildElement("groups");
       TiXmlElement* pGroupNode;
@@ -266,7 +260,7 @@ PVR_ERROR Channels::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNE
     PVR_CHANNEL_GROUP_MEMBER tag;
 
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       TiXmlElement* channelsNode = doc.RootElement()->FirstChildElement("channels");
       TiXmlElement* pChannelNode;

--- a/src/Channels.h
+++ b/src/Channels.h
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+
+#pragma once
+
+#include "BackendRequest.h"
+#include "tinyxml.h"
+
+using namespace ADDON;
+
+namespace NextPVR
+{
+
+  class Channels
+  {
+
+  public:
+    /**
+       * Singleton getter for the instance
+       */
+    static Channels& GetInstance()
+    {
+      static Channels channels;
+      return channels;
+    }
+
+    /* Channel handling */
+    int GetNumChannels(void);
+    PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
+
+    /* Channel group handling */
+    int GetChannelGroupsAmount(void);
+    PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio);
+    PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
+    bool IsChannelAPlugin(int uid);
+    void LoadLiveStreams();
+    std::map<int, std::string> m_liveStreams;
+    std::string GetChannelIconFileName(int channelID);
+    void DeleteChannelIcon(int channelID);
+    void DeleteChannelIcons();
+    PVR_RECORDING_CHANNEL_TYPE GetChannelType(unsigned int uid);
+
+  private:
+    Channels() = default;
+
+    Channels(Channels const&) = delete;
+    void operator=(Channels const&) = delete;
+
+    std::string GetChannelIcon(int channelID);
+    Settings& m_settings = Settings::GetInstance();
+    Request& m_request = Request::GetInstance();
+    std::map<int, std::pair<bool, bool>> m_channelDetails;
+
+  };
+} // namespace NextPVR

--- a/src/EPG.cpp
+++ b/src/EPG.cpp
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "EPG.h"
+
+#include "kodi/util/XMLUtils.h"
+#include "pvrclient-nextpvr.h"
+
+#include <p8-platform/util/StringUtils.h>
+
+#if defined(TARGET_WINDOWS)
+#define atoll(S) _atoi64(S)
+#else
+#define MAXINT64 ULONG_MAX
+#endif
+
+using namespace NextPVR;
+
+/************************************************************/
+/** EPG handling */
+
+PVR_ERROR EPG::GetEpg(ADDON_HANDLE handle, int iChannelUid, time_t iStart, time_t iEnd)
+{
+  EPG_TAG broadcast;
+
+  std::string response;
+
+  LOG_API_CALL(__FUNCTION__);
+
+  std::pair<bool, bool> channelDetail;
+  channelDetail = m_channelDetails[iChannelUid];
+  if (channelDetail.first == true)
+  {
+    XBMC->Log(LOG_DEBUG, "Skipping %d", iChannelUid);
+    return PVR_ERROR_NO_ERROR;
+  }
+
+  if (iEnd < (time(nullptr) - 24 * 3600))
+  {
+    XBMC->Log(LOG_DEBUG, "Skipping expired EPG data %d %ld %lld", iChannelUid, iStart, iEnd);
+    return PVR_ERROR_INVALID_PARAMETERS;
+  }
+  const std::string request = StringUtils::Format("/service?method=channel.listings&channel_id=%d&start=%d&end=%d&genre=all", iChannelUid, static_cast<int>(iStart), static_cast<int>(iEnd));
+  if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()))
+    {
+      TiXmlElement* listingsNode = doc.RootElement()->FirstChildElement("listings");
+      for (TiXmlElement* pListingNode = listingsNode->FirstChildElement("l"); pListingNode; pListingNode = pListingNode->NextSiblingElement())
+      {
+        broadcast = {0};
+        std::string title;
+        std::string description;
+        std::string subtitle;
+        XMLUtils::GetString(pListingNode, "name", title);
+        XMLUtils::GetString(pListingNode, "description", description);
+
+        if (XMLUtils::GetString(pListingNode, "subtitle", subtitle))
+        {
+          if (description != subtitle + ":" && StringUtils::StartsWith(description, subtitle + ": "))
+          {
+            description = description.substr(subtitle.length() + 2);
+          }
+        }
+
+        broadcast.iYear = g_pvrclient->XmlGetInt(pListingNode, "year");
+
+        std::string startTime;
+        std::string endTime;
+        XMLUtils::GetString(pListingNode, "start", startTime);
+        startTime.resize(10);
+        XMLUtils::GetString(pListingNode, "end", endTime);
+        endTime.resize(10);
+
+        const std::string oidLookup(endTime + ":" + std::to_string(iChannelUid));
+
+        const int epgOid = g_pvrclient->XmlGetInt(pListingNode, "id");
+        m_timers.m_epgOidLookup[oidLookup] = epgOid;
+
+        broadcast.strTitle = title.c_str();
+        broadcast.strEpisodeName = subtitle.c_str();
+        broadcast.iUniqueChannelId = iChannelUid;
+        broadcast.startTime = stol(startTime);
+        broadcast.iUniqueBroadcastId = stoi(endTime);
+        broadcast.endTime = stol(endTime);
+        broadcast.strPlot = description.c_str();
+
+        std::string artworkPath;
+        if (m_settings.m_downloadGuideArtwork)
+        {
+          // artwork URL
+          if (m_settings.m_backendVersion < 50000)
+            artworkPath = StringUtils::Format("http://%s:%d/service?method=channel.show.artwork&sid=%s&event_id=%d", m_settings.m_hostname.c_str(), m_settings.m_port, g_pvrclient->m_sid, epgOid);
+          else
+          {
+            if (m_settings.m_sendSidWithMetadata)
+              artworkPath = StringUtils::Format("http://%s:%d/service?method=channel.show.artwork&sid=%s&name=%s", m_settings.m_hostname.c_str(), m_settings.m_port, g_pvrclient->m_sid, UriEncode(title).c_str());
+            else
+              artworkPath = StringUtils::Format("http://%s:%d/service?method=channel.show.artwork&name=%s", m_settings.m_hostname.c_str(), m_settings.m_port, UriEncode(title).c_str());
+            if (m_settings.m_guideArtPortrait)
+              artworkPath += "&prefer=poster";
+          }
+          broadcast.strIconPath = artworkPath.c_str();
+        }
+        std::string sGenre;
+        if (XMLUtils::GetString(pListingNode, "genre", sGenre))
+        {
+          broadcast.strGenreDescription = sGenre.c_str();
+          broadcast.iGenreType = EPG_GENRE_USE_STRING;
+        }
+        else
+        {
+          // genre type
+          broadcast.iGenreType = g_pvrclient->XmlGetInt(pListingNode, "genre_type");
+          broadcast.iGenreSubType = g_pvrclient->XmlGetInt(pListingNode, "genre_sub_type");
+
+        }
+        std::string allGenres;
+        if (m_recordings.GetAdditiveString(pListingNode->FirstChildElement("genres"), "genre", EPG_STRING_TOKEN_SEPARATOR, allGenres, true))
+        {
+          if (allGenres.find(EPG_STRING_TOKEN_SEPARATOR) != std::string::npos)
+          {
+            if (broadcast.iGenreType != EPG_GENRE_USE_STRING)
+            {
+              broadcast.iGenreSubType = EPG_GENRE_USE_STRING;
+            }
+            broadcast.strGenreDescription = allGenres.c_str();
+          }
+        }
+        broadcast.iSeriesNumber = g_pvrclient->XmlGetInt(pListingNode, "season", EPG_TAG_INVALID_SERIES_EPISODE);
+        broadcast.iEpisodeNumber = g_pvrclient->XmlGetInt(pListingNode, "episode", EPG_TAG_INVALID_SERIES_EPISODE);
+        broadcast.iEpisodePartNumber = EPG_TAG_INVALID_SERIES_EPISODE;
+
+        std::string original;
+        XMLUtils::GetString(pListingNode, "original", original);
+        broadcast.strFirstAired = original.c_str();
+
+        bool firstrun;
+        if (XMLUtils::GetBoolean(pListingNode, "firstrun", firstrun))
+        {
+          if (firstrun)
+          {
+            std::string significance;
+            XMLUtils::GetString(pListingNode, "significance", significance);
+            if (significance == "Live")
+            {
+              broadcast.iFlags = EPG_TAG_FLAG_IS_LIVE;
+            }
+            else if (significance.find("Premiere") != std::string::npos)
+            {
+              broadcast.iFlags = EPG_TAG_FLAG_IS_PREMIERE;
+            }
+            else if (significance.find("Finale") != std::string::npos)
+            {
+              broadcast.iFlags = EPG_TAG_FLAG_IS_FINALE;
+            }
+            else if (m_settings.m_showNew)
+            {
+              broadcast.iFlags = EPG_TAG_FLAG_IS_NEW;
+            }
+          }
+        }
+        PVR->TransferEpgEntry(handle, &broadcast);
+      }
+    }
+  }
+
+  return PVR_ERROR_NO_ERROR;
+}

--- a/src/EPG.cpp
+++ b/src/EPG.cpp
@@ -13,12 +13,6 @@
 
 #include <p8-platform/util/StringUtils.h>
 
-#if defined(TARGET_WINDOWS)
-#define atoll(S) _atoi64(S)
-#else
-#define MAXINT64 ULONG_MAX
-#endif
-
 using namespace NextPVR;
 
 /************************************************************/

--- a/src/EPG.cpp
+++ b/src/EPG.cpp
@@ -21,11 +21,7 @@ using namespace NextPVR;
 PVR_ERROR EPG::GetEpg(ADDON_HANDLE handle, int iChannelUid, time_t iStart, time_t iEnd)
 {
   EPG_TAG broadcast;
-
   std::string response;
-
-  LOG_API_CALL(__FUNCTION__);
-
   std::pair<bool, bool> channelDetail;
   channelDetail = m_channelDetails[iChannelUid];
   if (channelDetail.first == true)

--- a/src/EPG.h
+++ b/src/EPG.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+
+#pragma once
+
+#include "BackendRequest.h"
+#include "tinyxml.h"
+#include "Recordings.h"
+#include "Timers.h"
+
+using namespace ADDON;
+
+namespace NextPVR
+{
+  class EPG
+  {
+  public:
+    /**
+       * Singleton getter for the instance
+       */
+    static EPG& GetInstance()
+    {
+      static EPG epg;
+      return epg;
+    }
+
+    PVR_ERROR GetEpg(ADDON_HANDLE handle, int iChannelUid, time_t iStart = 0, time_t iEnd = 0);
+    std::map<int, std::pair<bool, bool>> m_channelDetails;
+
+  private:
+    EPG() = default;
+
+    EPG(EPG const&) = delete;
+    void operator=(EPG const&) = delete;
+
+    Settings& m_settings = Settings::GetInstance();
+    Request& m_request = Request::GetInstance();
+    Timers& m_timers = Timers::GetInstance();
+    Recordings& m_recordings = Recordings::GetInstance();
+  };
+} // namespace NextPVR

--- a/src/MenuHook.cpp
+++ b/src/MenuHook.cpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "MenuHook.h"
+
+using namespace NextPVR;
+
+PVR_ERROR MenuHook::CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA& item)
+{
+  if (item.cat == PVR_MENUHOOK_CHANNEL && menuhook.iHookId == PVR_MENUHOOK_CHANNEL_DELETE_SINGLE_CHANNEL_ICON)
+  {
+    m_channels.DeleteChannelIcon(item.data.channel.iUniqueId);
+    PVR->TriggerChannelUpdate();
+  }
+  else if (item.cat == PVR_MENUHOOK_RECORDING && menuhook.iHookId == PVR_MENUHOOK_RECORDING_FORGET_RECORDING)
+  {
+    m_recordings.ForgetRecording(item.data.recording);
+  }
+  else if (item.cat == PVR_MENUHOOK_SETTING && menuhook.iHookId == PVR_MENUHOOK_SETTING_DELETE_ALL_CHANNNEL_ICONS)
+  {
+    m_channels.DeleteChannelIcons();
+    PVR->TriggerChannelUpdate();
+  }
+  else if (item.cat == PVR_MENUHOOK_SETTING && menuhook.iHookId == PVR_MENUHOOK_SETTING_UPDATE_CHANNNELS)
+  {
+    PVR->TriggerChannelUpdate();
+  }
+  else if (item.cat == PVR_MENUHOOK_SETTING && menuhook.iHookId == PVR_MENUHOOK_SETTING_UPDATE_CHANNNEL_GROUPS)
+  {
+    PVR->TriggerChannelGroupsUpdate();
+  }
+  return PVR_ERROR_NO_ERROR;
+}
+
+void MenuHook::ConfigureMenuHook()
+{
+  PVR_MENUHOOK menuHook;
+  menuHook = {0};
+  menuHook.category = PVR_MENUHOOK_CHANNEL;
+  menuHook.iHookId = PVR_MENUHOOK_CHANNEL_DELETE_SINGLE_CHANNEL_ICON;
+  menuHook.iLocalizedStringId = 30183;
+  PVR->AddMenuHook(&menuHook);
+
+  menuHook = {0};
+  menuHook.category = PVR_MENUHOOK_SETTING;
+  menuHook.iHookId = PVR_MENUHOOK_SETTING_DELETE_ALL_CHANNNEL_ICONS;
+  menuHook.iLocalizedStringId = 30170;
+  PVR->AddMenuHook(&menuHook);
+
+  menuHook = {0};
+  menuHook.category = PVR_MENUHOOK_SETTING;
+  menuHook.iHookId = PVR_MENUHOOK_SETTING_UPDATE_CHANNNELS;
+  menuHook.iLocalizedStringId = 30185;
+  PVR->AddMenuHook(&menuHook);
+
+  menuHook = {0};
+  menuHook.category = PVR_MENUHOOK_SETTING;
+  menuHook.iHookId = PVR_MENUHOOK_SETTING_UPDATE_CHANNNEL_GROUPS;
+  menuHook.iLocalizedStringId = 30186;
+  PVR->AddMenuHook(&menuHook);
+
+  if (m_settings.m_backendVersion >= 50000)
+  {
+    menuHook = {0};
+    menuHook.category = PVR_MENUHOOK_RECORDING;
+    menuHook.iHookId = PVR_MENUHOOK_RECORDING_FORGET_RECORDING;
+    menuHook.iLocalizedStringId = 30184;
+    PVR->AddMenuHook(&menuHook);
+  }
+}

--- a/src/MenuHook.h
+++ b/src/MenuHook.h
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+
+#pragma once
+
+#include "client.h"
+#include "Channels.h"
+#include "Recordings.h"
+#include "Settings.h"
+
+using namespace ADDON;
+
+namespace NextPVR
+{
+
+  constexpr int PVR_MENUHOOK_CHANNEL_DELETE_SINGLE_CHANNEL_ICON=101;
+  constexpr int PVR_MENUHOOK_RECORDING_FORGET_RECORDING=401;
+  constexpr int PVR_MENUHOOK_SETTING_DELETE_ALL_CHANNNEL_ICONS=601;
+  constexpr int PVR_MENUHOOK_SETTING_UPDATE_CHANNNELS=602;
+  constexpr int PVR_MENUHOOK_SETTING_UPDATE_CHANNNEL_GROUPS=603;
+
+
+  class MenuHook
+  {
+
+  public:
+    /**
+       * Singleton getter for the instance
+       */
+    static MenuHook& GetInstance()
+    {
+      static MenuHook menuhook;
+      return menuhook;
+    }
+
+    PVR_ERROR CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA& item);
+    void ConfigureMenuHook();
+
+
+  private:
+    MenuHook() = default;
+
+    MenuHook(MenuHook const&) = delete;
+    Channels& m_channels = Channels::GetInstance();
+    Recordings& m_recordings = Recordings::GetInstance();
+    Settings& m_settings = Settings::GetInstance();
+
+  };
+} // namespace NextPVR

--- a/src/Recordings.cpp
+++ b/src/Recordings.cpp
@@ -26,7 +26,6 @@ int Recordings::GetNumRecordings(void)
   // need something more optimal, but this will do for now...
   // Return -1 on error.
 
-  LOG_API_CALL(__FUNCTION__);
   if (m_iRecordingCount != 0)
     return m_iRecordingCount;
 
@@ -48,7 +47,6 @@ int Recordings::GetNumRecordings(void)
       }
     }
   }
-  LOG_API_IRET(__FUNCTION__, m_iRecordingCount);
   return m_iRecordingCount;
 }
 
@@ -57,7 +55,6 @@ PVR_ERROR Recordings::GetRecordings(ADDON_HANDLE handle)
   // include already-completed recordings
   PVR_ERROR returnValue = PVR_ERROR_NO_ERROR;
   m_hostFilenames.clear();
-  LOG_API_CALL(__FUNCTION__);
   int recordingCount = 0;
   std::string response;
   if (m_request.DoRequest("/service?method=recording.list&filter=all", response) == HTTP_OK)
@@ -99,7 +96,6 @@ PVR_ERROR Recordings::GetRecordings(ADDON_HANDLE handle)
     returnValue = PVR_ERROR_SERVER_ERROR;
   }
   g_pvrclient->m_lastRecordingUpdateTime = time(0);
-  LOG_API_IRET(__FUNCTION__, returnValue);
   return returnValue;
 }
 
@@ -341,9 +337,6 @@ void Recordings::ParseNextPVRSubtitle(const std::string episodeName, PVR_RECORDI
 
 PVR_ERROR Recordings::DeleteRecording(const PVR_RECORDING& recording)
 {
-  LOG_API_CALL(__FUNCTION__);
-  XBMC->Log(LOG_DEBUG, "DeleteRecording");
-
   if (recording.recordingTime < time(nullptr) && recording.recordingTime + recording.iDuration > time(nullptr))
     return PVR_ERROR_RECORDING_RUNNING;
 
@@ -366,7 +359,6 @@ PVR_ERROR Recordings::DeleteRecording(const PVR_RECORDING& recording)
 
 bool Recordings::ForgetRecording(const PVR_RECORDING& recording)
 {
-  LOG_API_CALL(__FUNCTION__);
   // tell backend to forget recording history so it can re recorded.
   std::string request = "/service?method=recording.forget&recording_id=";
   request.append(recording.strRecordingId);
@@ -376,8 +368,6 @@ bool Recordings::ForgetRecording(const PVR_RECORDING& recording)
 
 PVR_ERROR Recordings::SetRecordingLastPlayedPosition(const PVR_RECORDING& recording, int lastplayedposition)
 {
-  LOG_API_CALL(__FUNCTION__);
-  XBMC->Log(LOG_DEBUG, "SetRecordingLastPlayedPosition");
   const std::string request = StringUtils::Format("/service?method=recording.watched.set&recording_id=%s&position=%d", recording.strRecordingId, lastplayedposition);
 
   std::string response;
@@ -395,16 +385,12 @@ PVR_ERROR Recordings::SetRecordingLastPlayedPosition(const PVR_RECORDING& record
 
 int Recordings::GetRecordingLastPlayedPosition(const PVR_RECORDING& recording)
 {
-  LOG_API_CALL(__FUNCTION__);
   return recording.iLastPlayedPosition;
 }
 
 PVR_ERROR Recordings::GetRecordingEdl(const PVR_RECORDING& recording, PVR_EDL_ENTRY entries[], int* size)
 {
-  LOG_API_CALL(__FUNCTION__);
-  XBMC->Log(LOG_DEBUG, "GetRecordingEdl");
   const std::string request = StringUtils::Format("/service?method=recording.edl&recording_id=%s", recording.strRecordingId);
-
   std::string response;
   if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
   {

--- a/src/Recordings.cpp
+++ b/src/Recordings.cpp
@@ -1,0 +1,440 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "Recordings.h"
+
+#include "kodi/util/XMLUtils.h"
+
+#include "pvrclient-nextpvr.h"
+
+#include <regex>
+
+#include <p8-platform/util/StringUtils.h>
+
+#if defined(TARGET_WINDOWS)
+#define atoll(S) _atoi64(S)
+#else
+#define MAXINT64 ULONG_MAX
+#endif
+
+using namespace NextPVR;
+
+/************************************************************/
+/** Record handling **/
+
+int Recordings::GetNumRecordings(void)
+{
+  // need something more optimal, but this will do for now...
+  // Return -1 on error.
+
+  LOG_API_CALL(__FUNCTION__);
+  if (m_iRecordingCount != 0)
+    return m_iRecordingCount;
+
+  std::string response;
+  if (m_request.DoRequest("/service?method=recording.list&filter=ready", response) == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()) != NULL)
+    {
+      TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
+      if (recordingsNode != NULL)
+      {
+        TiXmlElement* pRecordingNode;
+        m_iRecordingCount = 0;
+        for (pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode = pRecordingNode->NextSiblingElement())
+        {
+          m_iRecordingCount++;
+        }
+      }
+    }
+  }
+  LOG_API_IRET(__FUNCTION__, m_iRecordingCount);
+  return m_iRecordingCount;
+}
+
+PVR_ERROR Recordings::GetRecordings(ADDON_HANDLE handle)
+{
+  // include already-completed recordings
+  PVR_ERROR returnValue = PVR_ERROR_NO_ERROR;
+  m_hostFilenames.clear();
+  LOG_API_CALL(__FUNCTION__);
+  int recordingCount = 0;
+  std::string response;
+  if (m_request.DoRequest("/service?method=recording.list&filter=all", response) == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()) != NULL)
+    {
+      //dump_to_log(&doc, 0);
+      PVR_RECORDING tag;
+      TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
+      TiXmlElement* pRecordingNode;
+      std::map<std::string, int> names;
+      if (m_settings.m_flattenRecording)
+      {
+        for (pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode = pRecordingNode->NextSiblingElement())
+        {
+          std::string title;
+          XMLUtils::GetString(pRecordingNode, "name", title);
+          names[title]++;
+        }
+      }
+      for (pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode = pRecordingNode->NextSiblingElement())
+      {
+        tag = {};
+        std::string title;
+        XMLUtils::GetString(pRecordingNode, "name", title);
+        if (UpdatePvrRecording(pRecordingNode, &tag, title, names[title] == 1))
+        {
+          recordingCount++;
+          PVR->TransferRecordingEntry(handle, &tag);
+        }
+      }
+    }
+    m_iRecordingCount = recordingCount;
+    XBMC->Log(LOG_DEBUG, "Updated recordings %lld", g_pvrclient->m_lastRecordingUpdateTime);
+  }
+  else
+  {
+    returnValue = PVR_ERROR_SERVER_ERROR;
+  }
+  g_pvrclient->m_lastRecordingUpdateTime = time(0);
+  LOG_API_IRET(__FUNCTION__, returnValue);
+  return returnValue;
+}
+
+bool Recordings::UpdatePvrRecording(TiXmlElement* pRecordingNode, PVR_RECORDING* tag, const std::string& title, bool flatten)
+{
+  std::string buffer;
+  title.copy(tag->strTitle, sizeof(tag->strTitle) - 1);
+
+  tag->recordingTime = atol(pRecordingNode->FirstChildElement("start_time_ticks")->FirstChild()->Value());
+
+  std::string status;
+  XMLUtils::GetString(pRecordingNode, "status", status);
+  if (status == "Pending" && tag->recordingTime > time(nullptr) + m_settings.m_serverTimeOffset)
+  {
+    // skip timers
+    return false;
+  }
+  tag->iDuration = atoi(pRecordingNode->FirstChildElement("duration_seconds")->FirstChild()->Value());
+
+  if (status == "Ready" || status == "Pending" || status == "Recording")
+  {
+    if (!flatten)
+    {
+      buffer = StringUtils::Format("/%s", title.c_str());
+      buffer.copy(tag->strDirectory, sizeof(tag->strDirectory) - 1);
+    }
+    buffer.clear();
+    if (XMLUtils::GetString(pRecordingNode, "desc", buffer))
+    {
+      buffer.copy(tag->strPlot, sizeof(tag->strPlot) - 1);
+    }
+  }
+  else if (status == "Failed")
+  {
+    buffer = StringUtils::Format("/%s/%s", XBMC->GetLocalizedString(30166), title.c_str());
+    buffer.copy(tag->strDirectory, sizeof(tag->strDirectory) - 1);
+    if (XMLUtils::GetString(pRecordingNode, "reason", buffer))
+    {
+      buffer.copy(tag->strPlot, sizeof(tag->strPlot) - 1);
+    }
+    if (tag->iDuration < 0)
+    {
+      tag->iDuration = 0;
+    }
+  }
+  else if (status == "Conflict")
+  {
+    // shouldn't happen;
+    return false;
+  }
+  else
+  {
+    XBMC->Log(LOG_ERROR, "Unknown status %s", status.c_str());
+    return false;
+  }
+
+  if (status == "Recording" || status == "Pending")
+  {
+    tag->iEpgEventId = g_pvrclient->XmlGetInt(pRecordingNode, "epg_event_oid", PVR_TIMER_NO_EPG_UID);
+    if (tag->iEpgEventId != PVR_TIMER_NO_EPG_UID)
+    {
+      // EPG Event ID is likely not valid on most older recordings so current or pending only
+      // Linked tags need to be on end time because recordingTime can change because of pre-padding
+
+      tag->iEpgEventId = tag->recordingTime + tag->iDuration;
+    }
+  }
+
+  buffer.clear();
+  XMLUtils::GetString(pRecordingNode, "id", buffer);
+  buffer.copy(tag->strRecordingId, buffer.length());
+
+  tag->iSeriesNumber = PVR_RECORDING_INVALID_SERIES_EPISODE;
+  tag->iEpisodeNumber = PVR_RECORDING_INVALID_SERIES_EPISODE;
+
+  if (XMLUtils::GetString(pRecordingNode, "subtitle", buffer))
+  {
+    if (m_settings.m_kodiLook || flatten)
+    {
+      ParseNextPVRSubtitle(buffer, tag);
+    }
+    else
+    {
+      buffer.copy(tag->strTitle, sizeof(tag->strTitle) - 1);
+    }
+  }
+  int lookup;
+  tag->iLastPlayedPosition = g_pvrclient->XmlGetInt(pRecordingNode,"playback_position",lookup);
+  if (XMLUtils::GetInt(pRecordingNode, "channel_id", lookup))
+  {
+    if (lookup == 0)
+    {
+      tag->iChannelUid = PVR_CHANNEL_INVALID_UID;
+    }
+    else
+    {
+      tag->iChannelUid = lookup;
+      strcpy(tag->strIconPath, g_pvrclient->m_channels.GetChannelIconFileName(tag->iChannelUid).c_str());
+    }
+  }
+  else
+  {
+    tag->iChannelUid = PVR_CHANNEL_INVALID_UID;
+  }
+  if (XMLUtils::GetString(pRecordingNode, "channel", buffer))
+  {
+    buffer.copy(tag->strChannelName, buffer.length());
+  }
+
+  std::string recordingFile;
+  if (XMLUtils::GetString(pRecordingNode, "file", recordingFile))
+  {
+    if (m_settings.m_showRecordingSize)
+    {
+      StringUtils::Replace(recordingFile, '\\', '/');
+      if (StringUtils::StartsWith(recordingFile, "//"))
+      {
+        recordingFile = "smb:" + recordingFile;
+      }
+      if (XBMC->FileExists(recordingFile.c_str(), READ_NO_CACHE))
+      {
+        void* fileHandle = XBMC->OpenFile(recordingFile.c_str(), READ_NO_CACHE);
+        tag->sizeInBytes = XBMC->GetFileLength(fileHandle);
+        XBMC->CloseFile(fileHandle);
+      }
+      else
+      {
+        // don't play recording as file
+        recordingFile.clear();
+      }
+    }
+  }
+
+  m_hostFilenames[tag->strRecordingId] = recordingFile;
+
+  // if we use unknown Kodi logs warning and turns it to TV so save some steps
+  tag->channelType = g_pvrclient->m_channels.GetChannelType(tag->iChannelUid);
+  if (tag->channelType != PVR_RECORDING_CHANNEL_TYPE_RADIO)
+  {
+    std::string artworkPath;
+    if (m_settings.m_backendVersion < 50000)
+    {
+      artworkPath = StringUtils::Format("http://%s:%d/service?method=recording.artwork&sid=%s&recording_id=%s", m_settings.m_hostname.c_str(), m_settings.m_port, g_pvrclient->m_sid, tag->strRecordingId);
+      artworkPath.copy(tag->strThumbnailPath, sizeof(tag->strThumbnailPath) - 1);
+      artworkPath = StringUtils::Format("http://%s:%d/service?method=recording.fanart&sid=%s&recording_id=%s", m_settings.m_hostname.c_str(), m_settings.m_port, g_pvrclient->m_sid, tag->strRecordingId);
+      artworkPath.copy(tag->strFanartPath, sizeof(tag->strFanartPath) - 1);
+    }
+    else
+    {
+      if (m_settings.m_sendSidWithMetadata)
+        artworkPath = StringUtils::Format("http://%s:%d/service?method=channel.show.artwork&sid=%s&name=%s", m_settings.m_hostname.c_str(), m_settings.m_port, g_pvrclient->m_sid, UriEncode(title).c_str());
+      else
+        artworkPath = StringUtils::Format("http://%s:%d/service?method=channel.show.artwork&name=%s", m_settings.m_hostname.c_str(), m_settings.m_port, UriEncode(title).c_str());
+      artworkPath.copy(tag->strFanartPath, sizeof(tag->strFanartPath) - 1);
+      artworkPath += "&prefer=poster";
+      artworkPath.copy(tag->strThumbnailPath, sizeof(tag->strThumbnailPath) - 1);
+    }
+  }
+  if (GetAdditiveString(pRecordingNode->FirstChildElement("genres"), "genre", EPG_STRING_TOKEN_SEPARATOR, buffer, true))
+  {
+    tag->iGenreType = EPG_GENRE_USE_STRING;
+    tag->iGenreSubType = 0;
+    buffer.copy(tag->strGenreDescription, sizeof(tag->strGenreDescription) - 1);
+  }
+
+  std::string significance;
+  XMLUtils::GetString(pRecordingNode, "significance", significance);
+  if (significance.find("Premiere") != std::string::npos)
+  {
+    tag->iFlags = PVR_RECORDING_FLAG_IS_PREMIERE;
+  }
+  else if (significance.find("Finale") != std::string::npos)
+  {
+    tag->iFlags = PVR_RECORDING_FLAG_IS_FINALE;
+  }
+
+  bool played = false;
+  if (XMLUtils::GetBoolean(pRecordingNode, "played", played))
+  {
+    tag->iPlayCount = 1;
+  }
+
+  return true;
+}
+
+bool Recordings::GetAdditiveString(const TiXmlNode* pRootNode, const char* strTag, const std::string& strSeparator, std::string& strStringValue, bool clear)
+{
+  bool bResult = false;
+  if (pRootNode != nullptr)
+  {
+    std::string strTemp;
+    const TiXmlElement* node = pRootNode->FirstChildElement(strTag);
+    if (node && node->FirstChild() && clear)
+      strStringValue.clear();
+    while (node)
+    {
+      if (node->FirstChild())
+      {
+        bResult = true;
+        strTemp = node->FirstChild()->Value();
+        const char* clear = node->Attribute("clear");
+        if (strStringValue.empty() || (clear && StringUtils::CompareNoCase(clear, "true") == 0))
+          strStringValue = strTemp;
+        else
+          strStringValue += strSeparator + strTemp;
+      }
+      node = node->NextSiblingElement(strTag);
+    }
+  }
+
+  return bResult;
+}
+
+void Recordings::ParseNextPVRSubtitle(const std::string episodeName, PVR_RECORDING* tag)
+{
+  std::regex base_regex("S(\\d\\d)E(\\d+) - ?(.+)?");
+  std::smatch base_match;
+  // note NextPVR does not support S0 for specials
+  if (std::regex_match(episodeName, base_match, base_regex))
+  {
+    if (base_match.size() == 3 || base_match.size() == 4)
+    {
+      std::ssub_match base_sub_match = base_match[1];
+      tag->iSeriesNumber = std::stoi(base_sub_match.str());
+      base_sub_match = base_match[2];
+      tag->iEpisodeNumber = std::stoi(base_sub_match.str());
+      if (base_match.size() == 4)
+      {
+        base_sub_match = base_match[3];
+        strcpy(tag->strEpisodeName, base_sub_match.str().c_str());
+      }
+    }
+  }
+  else
+  {
+    episodeName.copy(tag->strEpisodeName, sizeof(tag->strEpisodeName) - 1);
+  }
+}
+
+PVR_ERROR Recordings::DeleteRecording(const PVR_RECORDING& recording)
+{
+  LOG_API_CALL(__FUNCTION__);
+  XBMC->Log(LOG_DEBUG, "DeleteRecording");
+
+  if (recording.recordingTime < time(nullptr) && recording.recordingTime + recording.iDuration > time(nullptr))
+    return PVR_ERROR_RECORDING_RUNNING;
+
+  const std::string request = StringUtils::Format("/service?method=recording.delete&recording_id=%s", recording.strRecordingId);
+
+  std::string response;
+  if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
+  {
+    if (strstr(response.c_str(), "<rsp stat=\"ok\">"))
+    {
+      return PVR_ERROR_NO_ERROR;
+    }
+  }
+  else
+  {
+    XBMC->Log(LOG_DEBUG, "DeleteRecording failed");
+  }
+  return PVR_ERROR_FAILED;
+}
+
+bool Recordings::ForgetRecording(const PVR_RECORDING& recording)
+{
+  LOG_API_CALL(__FUNCTION__);
+  // tell backend to forget recording history so it can re recorded.
+  std::string request = "/service?method=recording.forget&recording_id=";
+  request.append(recording.strRecordingId);
+  std::string response;
+  return m_request.DoRequest(request.c_str(), response) == HTTP_OK;
+}
+
+PVR_ERROR Recordings::SetRecordingLastPlayedPosition(const PVR_RECORDING& recording, int lastplayedposition)
+{
+  LOG_API_CALL(__FUNCTION__);
+  XBMC->Log(LOG_DEBUG, "SetRecordingLastPlayedPosition");
+  const std::string request = StringUtils::Format("/service?method=recording.watched.set&recording_id=%s&position=%d", recording.strRecordingId, lastplayedposition);
+
+  std::string response;
+  if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
+  {
+    if (strstr(response.c_str(), "<rsp stat=\"ok\">") == NULL)
+    {
+      XBMC->Log(LOG_DEBUG, "SetRecordingLastPlayedPosition failed");
+      return PVR_ERROR_FAILED;
+    }
+    g_pvrclient->m_lastRecordingUpdateTime = 0;
+  }
+  return PVR_ERROR_NO_ERROR;
+}
+
+int Recordings::GetRecordingLastPlayedPosition(const PVR_RECORDING& recording)
+{
+  LOG_API_CALL(__FUNCTION__);
+  return recording.iLastPlayedPosition;
+}
+
+PVR_ERROR Recordings::GetRecordingEdl(const PVR_RECORDING& recording, PVR_EDL_ENTRY entries[], int* size)
+{
+  LOG_API_CALL(__FUNCTION__);
+  XBMC->Log(LOG_DEBUG, "GetRecordingEdl");
+  const std::string request = StringUtils::Format("/service?method=recording.edl&recording_id=%s", recording.strRecordingId);
+
+  std::string response;
+  if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
+  {
+    if (strstr(response.c_str(), "<rsp stat=\"ok\">") != NULL)
+    {
+      TiXmlDocument doc;
+      if (doc.Parse(response.c_str()) != NULL)
+      {
+        int index = 0;
+        TiXmlElement* commercialsNode = doc.RootElement()->FirstChildElement("commercials");
+        TiXmlElement* pCommercialNode;
+        for (pCommercialNode = commercialsNode->FirstChildElement("commercial"); pCommercialNode; pCommercialNode = pCommercialNode->NextSiblingElement())
+        {
+          PVR_EDL_ENTRY entry;
+          entry.start = atoll(pCommercialNode->FirstChildElement("start")->FirstChild()->Value()) * 1000;
+          entry.end = atoll(pCommercialNode->FirstChildElement("end")->FirstChild()->Value()) * 1000;
+          entry.type = PVR_EDL_TYPE_COMBREAK;
+          entries[index] = entry;
+          index++;
+        }
+        *size = index;
+        return PVR_ERROR_NO_ERROR;
+      }
+    }
+  }
+  return PVR_ERROR_FAILED;
+}

--- a/src/Recordings.h
+++ b/src/Recordings.h
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+
+#pragma once
+
+#include "BackendRequest.h"
+#include "tinyxml.h"
+
+using namespace ADDON;
+
+namespace NextPVR
+{
+
+  class Recordings
+  {
+
+  public:
+    /**
+       * Singleton getter for the instance
+       */
+    static Recordings& GetInstance()
+    {
+      static Recordings recordings;
+      return recordings;
+    }
+
+    /* Recording handling **/
+    int GetNumRecordings(void);
+    PVR_ERROR GetRecordings(ADDON_HANDLE handle);
+    PVR_ERROR DeleteRecording(const PVR_RECORDING& recording);
+    PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING& recording, int lastplayedposition);
+    int GetRecordingLastPlayedPosition(const PVR_RECORDING& recording);
+    PVR_ERROR GetRecordingEdl(const PVR_RECORDING& recording, PVR_EDL_ENTRY[], int* size);
+    PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*);
+    bool UpdatePvrRecording(TiXmlElement* pRecordingNode, PVR_RECORDING* tag, const std::string& title, bool flatten);
+    void ParseNextPVRSubtitle(const std::string episodeName, PVR_RECORDING* tag);
+    bool ForgetRecording(const PVR_RECORDING& recording);
+    std::map<std::string, std::string> m_hostFilenames;
+    bool GetAdditiveString(const TiXmlNode* pRootNode, const char* strTag, const std::string& strSeparator, std::string& strStringValue, bool clear);
+
+
+  private:
+    Recordings() = default;
+
+    Recordings(Recordings const&) = delete;
+    void operator=(Recordings const&) = delete;
+
+    Settings& m_settings = Settings::GetInstance();
+    Request& m_request = Request::GetInstance();
+    // update these at end of counting loop can be called during action
+    int m_iRecordingCount = -1;
+
+  };
+} // namespace NextPVR

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -110,7 +110,7 @@ ADDON_STATUS Settings::ReadBackendSettings()
   if (request.DoRequest("/service?method=setting.list", settings) == HTTP_OK)
   {
     TiXmlDocument settingsDoc;
-    if (settingsDoc.Parse(settings.c_str()) != NULL)
+    if (settingsDoc.Parse(settings.c_str()) != nullptr)
     {
       //dump_to_log(&settingsDoc, 0);
       if (XMLUtils::GetInt(settingsDoc.RootElement(), "NextPVRVersion", m_backendVersion))
@@ -157,18 +157,15 @@ ADDON_STATUS Settings::ReadBackendSettings()
       std::string serverMac;
       if (XMLUtils::GetString(settingsDoc.RootElement(), "ServerMAC", serverMac))
       {
-        char rawMAC[13];
-        PVR_STRCPY(rawMAC, serverMac.c_str());
-        if (strlen(rawMAC) == 12)
+        std::string macAddress = serverMac.substr(0,2) ;
+        for (int i = 2; i < 12; i+=2)
         {
-          char mac[18];
-          sprintf(mac, "%2.2s:%2.2s:%2.2s:%2.2s:%2.2s:%2.2s", rawMAC, &rawMAC[2], &rawMAC[4], &rawMAC[6], &rawMAC[8], &rawMAC[10]);
-          XBMC->Log(LOG_DEBUG, "Server MAC addres %4.4s...", mac);
-          std::string smac = mac;
-          if (m_hostMACAddress != smac)
-          {
-            SaveSettings("host_mac", smac);
-          }
+          macAddress+= ":" + serverMac.substr(i,2);
+        }
+        XBMC->Log(LOG_DEBUG, "Server MAC address %4.4s...", macAddress.c_str());
+        if (m_hostMACAddress != macAddress)
+        {
+          SaveSettings("host_mac", macAddress);
         }
       }
     }
@@ -255,7 +252,7 @@ bool Settings::SaveSettings(std::string name, std::string value)
         {
           if (key_value == name)
           {
-            if (childNode->FirstChild() != NULL)
+            if (childNode->FirstChild() != nullptr)
             {
               childNode->FirstChild()->SetValue(value);
               found = true;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -9,11 +9,11 @@
 
 #include "Settings.h"
 #include "BackendRequest.h"
+#include "uri.h"
 
 #include <kodi/util/XMLUtils.h>
 #include <p8-platform/util/StringUtils.h>
 #include <tinyxml.h>
-#include "uri.h"
 
 using namespace std;
 using namespace ADDON;
@@ -45,7 +45,7 @@ void Settings::ReadFromAddon()
     XBMC->Log(LOG_ERROR, "Couldn't get 'port' setting, falling back to '8866' as default");
     m_port = DEFAULT_PORT;
   }
-    /* Read setting "pin" from settings.xml */
+  /* Read setting "pin" from settings.xml */
 
   if (!XBMC->GetSetting("pin", buffer))
     m_PIN = DEFAULT_PIN;
@@ -97,7 +97,7 @@ void Settings::ReadFromAddon()
   if (!XBMC->GetSetting("showradio", &m_showRadio))
     m_showRadio = true;
 
-/* Log the current settings for debugging purposes */
+  /* Log the current settings for debugging purposes */
   XBMC->Log(LOG_DEBUG, "settings: host='%s', port=%i, mac=%4.4s...", m_hostname.c_str(), m_port, m_hostMACAddress.c_str());
 
 }
@@ -136,19 +136,12 @@ ADDON_STATUS Settings::ReadBackendSettings()
       XMLUtils::GetInt(settingsDoc.RootElement(), "PostPadding", m_defaultPostPadding);
 
       m_showNew = false;
-      XMLUtils::GetBoolean(settingsDoc.RootElement(),"ShowNewInGuide",m_showNew);
+      XMLUtils::GetBoolean(settingsDoc.RootElement(), "ShowNewInGuide", m_showNew);
 
       std::string recordingDirectories;
-      if (XMLUtils::GetString(settingsDoc.RootElement(),"RecordingDirectories",recordingDirectories))
+      if (XMLUtils::GetString(settingsDoc.RootElement(), "RecordingDirectories", recordingDirectories))
       {
         m_recordingDirectories = StringUtils::Split(recordingDirectories, ",", 0);
-        /*
-        vector<std::string> directories = split(recordingDirectories, ",", false);
-        for (size_t i = 0; i < directories.size(); i++)
-        {
-          m_recordingDirectories.push_back(directories[i]);
-        }
-        */
       }
 
       int serverTimestamp;
@@ -164,7 +157,6 @@ ADDON_STATUS Settings::ReadBackendSettings()
       std::string serverMac;
       if (XMLUtils::GetString(settingsDoc.RootElement(), "ServerMAC", serverMac))
       {
-        // only available from Windows backend
         char rawMAC[13];
         PVR_STRCPY(rawMAC, serverMac.c_str());
         if (strlen(rawMAC) == 12)
@@ -248,7 +240,7 @@ bool Settings::SaveSettings(std::string name, std::string value)
   bool found = false;
   TiXmlDocument doc;
 
-  char *settings = XBMC->TranslateSpecialProtocol("special://profile/addon_data/pvr.nextpvr/settings.xml");
+  char* settings = XBMC->TranslateSpecialProtocol("special://profile/addon_data/pvr.nextpvr/settings.xml");
   if (doc.LoadFile(settings))
   {
     //Get Root Node
@@ -259,13 +251,13 @@ bool Settings::SaveSettings(std::string name, std::string value)
       std::string key_value;
       for (childNode = rootNode->FirstChildElement("setting"); childNode; childNode = childNode->NextSiblingElement())
       {
-        if ( childNode->QueryStringAttribute("id", &key_value) == TIXML_SUCCESS)
+        if (childNode->QueryStringAttribute("id", &key_value) == TIXML_SUCCESS)
         {
           if (key_value == name)
           {
             if (childNode->FirstChild() != NULL)
             {
-              childNode->FirstChild()->SetValue( value );
+              childNode->FirstChild()->SetValue(value);
               found = true;
               break;
             }
@@ -275,8 +267,8 @@ bool Settings::SaveSettings(std::string name, std::string value)
       }
       if (found == false)
       {
-        TiXmlElement *newSetting = new TiXmlElement("setting");
-        TiXmlText *newvalue = new TiXmlText(value);
+        TiXmlElement* newSetting = new TiXmlElement("setting");
+        TiXmlText* newvalue = new TiXmlText(value);
         newSetting->SetAttribute("id", name);
         newSetting->LinkEndChild(newvalue);
         rootNode->LinkEndChild(newSetting);
@@ -310,18 +302,18 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
   else if (settingName == "guideartwork")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_downloadGuideArtwork, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
   else if (settingName == "guideartworkportrait")
-    return SetSetting<bool,ADDON_STATUS>(settingName, settingValue, m_guideArtPortrait, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_guideArtPortrait, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
   else if (settingName == "recordingsize")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_showRecordingSize, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
   else if (settingName == "flattenrecording")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_flattenRecording, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
   else if (settingName == "kodilook")
-    return SetSetting<bool ,ADDON_STATUS>(settingName, settingValue, m_kodiLook, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_kodiLook, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
   else if (settingName == "host_mac")
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_hostMACAddress, ADDON_STATUS_OK, ADDON_STATUS_OK);
-  else if (settingName == "livestreamingmethod" && g_client && m_backendVersion < 50000)
+  else if (settingName == "livestreamingmethod" && g_pvrclient && m_backendVersion < 50000)
     return SetSetting<eStreamingMethod, ADDON_STATUS>(settingName, settingValue, m_liveStreamingMethod, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
-  else if (settingName == "livestreamingmethod5" && g_client && m_backendVersion >= 50000 && *static_cast<const eStreamingMethod*>(settingValue) != Default)
+  else if (settingName == "livestreamingmethod5" && g_pvrclient && m_backendVersion >= 50000 && *static_cast<const eStreamingMethod*>(settingValue) != Default)
     return SetSetting<eStreamingMethod, ADDON_STATUS>(settingName, settingValue, m_liveStreamingMethod, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "prebuffer")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_prebuffer, ADDON_STATUS_OK, ADDON_STATUS_OK);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -10,23 +10,24 @@
 #pragma once
 
 #include "client.h"
+#include <string>
 #include <kodi/AddonBase.h>
 #include <p8-platform/util/StringUtils.h>
-#include <string>
+
 
 using namespace ADDON;
 
 namespace NextPVR
 {
-  #define PVRCLIENT_NEXTPVR_VERSION_STRING "1.0.0.0"
-  #define NEXTPVRC_MIN_VERSION_STRING "4.2.4"
-  #define DEFAULT_HOST                  "127.0.0.1"
-  #define DEFAULT_PORT                  8866
-  #define DEFAULT_PIN                   "0000"
-  #define DEFAULT_RADIO                 true
-  #define DEFAULT_USE_TIMESHIFT         false
-  #define DEFAULT_GUIDE_ARTWORK         false
-  #define DEFAULT_LIVE_STREAM           RealTime
+#define PVRCLIENT_NEXTPVR_VERSION_STRING "1.0.0.0"
+#define NEXTPVRC_MIN_VERSION_STRING "4.2.4"
+#define DEFAULT_HOST "127.0.0.1"
+#define DEFAULT_PORT 8866
+#define DEFAULT_PIN "0000"
+#define DEFAULT_RADIO true
+#define DEFAULT_USE_TIMESHIFT false
+#define DEFAULT_GUIDE_ARTWORK false
+#define DEFAULT_LIVE_STREAM RealTime
 
   enum eStreamingMethod
   {
@@ -99,7 +100,7 @@ namespace NextPVR
     //Timers
     int m_defaultPrePadding = 0;
     int m_defaultPostPadding = 0;
-    std::vector< std::string > m_recordingDirectories;
+    std::vector<std::string> m_recordingDirectories;
 
     //Timeshift
     int m_timeshiftBufferSeconds = 1200;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -19,15 +19,6 @@ using namespace ADDON;
 
 namespace NextPVR
 {
-#define PVRCLIENT_NEXTPVR_VERSION_STRING "1.0.0.0"
-#define NEXTPVRC_MIN_VERSION_STRING "4.2.4"
-#define DEFAULT_HOST "127.0.0.1"
-#define DEFAULT_PORT 8866
-#define DEFAULT_PIN "0000"
-#define DEFAULT_RADIO true
-#define DEFAULT_USE_TIMESHIFT false
-#define DEFAULT_GUIDE_ARTWORK false
-#define DEFAULT_LIVE_STREAM RealTime
 
   enum eStreamingMethod
   {
@@ -44,6 +35,16 @@ namespace NextPVR
     Portrait = 0,
     Landscape = 1
   };
+
+  const static std::string PVRCLIENT_NEXTPVR_VERSION_STRING = "1.0.0.0";
+  constexpr char NEXTPVRC_MIN_VERSION_STRING[] = "4.2.4";
+  const static std::string DEFAULT_HOST = "127.0.0.1";
+  constexpr bool DEFAULT_PORT = 8866;
+  const static std::string DEFAULT_PIN = "0000";
+  constexpr bool DEFAULT_RADIO = true;
+  constexpr bool DEFAULT_USE_TIMESHIFT = false;
+  constexpr bool DEFAULT_GUIDE_ARTWORK = false;
+  constexpr eStreamingMethod DEFAULT_LIVE_STREAM = RealTime;
 
   class Settings
   {

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -21,7 +21,7 @@ namespace NextPVR
 {
 
 /* Master defines for client control */
-#define RECEIVE_TIMEOUT 6 //sec
+constexpr long RECEIVE_TIMEOUT=6; //sec
 
 Socket::Socket(const enum SocketFamily family, const enum SocketDomain domain, const enum SocketType type, const enum SocketProtocol protocol)
 {
@@ -56,7 +56,7 @@ bool Socket::setHostname ( const std::string& host )
   if (isalpha(host.c_str()[0]))
   {
     // host address is a name
-    struct hostent *he = NULL;
+    struct hostent *he = nullptr;
     if ((he = gethostbyname( host.c_str() )) == 0)
     {
       errormessage( getLastError(), "Socket::setHostname");
@@ -82,7 +82,7 @@ bool Socket::read_ready()
   struct timeval tv = { 1, 0 };
   //  tv.tv_sec = 1;
 
-  int retVal = select(_sd+1, &fdset, NULL, NULL, &tv);
+  int retVal = select(_sd+1, &fdset, nullptr, nullptr, &tv);
   if (retVal > 0)
     return true;
   return false;
@@ -239,7 +239,7 @@ int Socket::send ( const char* data, const unsigned int len )
   FD_SET(_sd, &set_w);
   FD_SET(_sd, &set_e);
 
-  result = select(FD_SETSIZE, &set_w, NULL, &set_e, &tv);
+  result = select(FD_SETSIZE, &set_w, nullptr, &set_e, &tv);
 
   if (result < 0)
   {
@@ -289,7 +289,7 @@ int Socket::sendto ( const char* data, unsigned int size, bool sendcompletebuffe
 
 int Socket::receive ( std::string& data, unsigned int minpacketsize ) const
 {
-  char * buf = NULL;
+  char * buf = nullptr;
   int status = 0;
 
   if (!is_valid())
@@ -358,7 +358,7 @@ bool Socket::ReadResponse (int &code, vector<string> &lines)
     FD_ZERO(&set_e);
     FD_SET(_sd, &set_r);
     FD_SET(_sd, &set_e);
-    result = select(FD_SETSIZE, &set_r, NULL, &set_e, &timeout);
+    result = select(FD_SETSIZE, &set_r, nullptr, &set_e, &timeout);
 
     if (result < 0)
     {
@@ -570,7 +570,7 @@ bool Socket::set_non_blocking ( const bool b )
 
 void Socket::errormessage( int errnum, const char* functionname) const
 {
-  const char* errmsg = NULL;
+  const char* errmsg = nullptr;
 
   switch (errnum)
   {
@@ -718,7 +718,7 @@ bool Socket::set_non_blocking ( const bool b )
 
 void Socket::errormessage( int errnum, const char* functionname) const
 {
-  const char* errmsg = NULL;
+  const char* errmsg = nullptr;
 
   switch ( errnum )
   {

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -263,7 +263,7 @@ class Socket
      * \param fromlen    Optional, only required if 'from' is given: length of from struct
      * \return    Number of bytes received or SOCKET_ERROR
      */
-    int recvfrom ( char* data, const int buffersize, struct sockaddr* from = NULL, socklen_t* fromlen = NULL) const;
+    int recvfrom ( char* data, const int buffersize, struct sockaddr* from = nullptr, socklen_t* fromlen = nullptr) const;
 
     bool set_non_blocking ( const bool );
 
@@ -291,7 +291,7 @@ class Socket
       static int win_usage_count;       ///< Internal Windows usage counter used to prevent a global WSACleanup when more than one Socket object is used
     #endif
 
-    void errormessage( int errornum, const char* functionname = NULL) const;
+    void errormessage( int errornum, const char* functionname = nullptr) const;
     int getLastError(void) const;
     bool osInit();
     void osCleanup();

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -14,12 +14,6 @@
 
 #include <p8-platform/util/StringUtils.h>
 
-#if defined(TARGET_WINDOWS)
-#define atoll(S) _atoi64(S)
-#else
-#define MAXINT64 ULONG_MAX
-#endif
-
 using namespace NextPVR;
 
 /************************************************************/
@@ -38,10 +32,10 @@ int Timers::GetNumTimers(void)
   if (m_request.DoRequest("/service?method=recording.recurring.list", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recurrings");
-      if (recordingsNode != NULL)
+      if (recordingsNode != nullptr)
       {
         TiXmlElement* pRecordingNode;
         for (pRecordingNode = recordingsNode->FirstChildElement("recurring"); pRecordingNode; pRecordingNode = pRecordingNode->NextSiblingElement())
@@ -58,10 +52,10 @@ int Timers::GetNumTimers(void)
   if (m_request.DoRequest("/service?method=recording.list&filter=pending", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
-      if (recordingsNode != NULL)
+      if (recordingsNode != nullptr)
       {
         TiXmlElement* pRecordingNode;
         for (pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode = pRecordingNode->NextSiblingElement())
@@ -89,7 +83,7 @@ PVR_ERROR Timers::GetTimers(ADDON_HANDLE& handle)
   if (m_request.DoRequest("/service?method=recording.recurring.list", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       PVR_TIMER tag;
       TiXmlElement* recurringsNode = doc.RootElement()->FirstChildElement("recurrings");
@@ -220,7 +214,7 @@ PVR_ERROR Timers::GetTimers(ADDON_HANDLE& handle)
     if (m_request.DoRequest("/service?method=recording.list&filter=pending", response) == HTTP_OK)
     {
       TiXmlDocument doc;
-      if (doc.Parse(response.c_str()) != NULL)
+      if (doc.Parse(response.c_str()) != nullptr)
       {
         PVR_TIMER tag;
 
@@ -238,7 +232,7 @@ PVR_ERROR Timers::GetTimers(ADDON_HANDLE& handle)
       if (m_request.DoRequest("/service?method=recording.list&filter=conflict", response) == HTTP_OK)
       {
         TiXmlDocument doc;
-        if (doc.Parse(response.c_str()) != NULL)
+        if (doc.Parse(response.c_str()) != nullptr)
         {
           PVR_TIMER tag;
           TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -21,7 +21,6 @@ using namespace NextPVR;
 
 int Timers::GetNumTimers(void)
 {
-  LOG_API_CALL(__FUNCTION__);
   // Return -1 in case of error.
   if (m_iTimerCount != -1)
     return m_iTimerCount;
@@ -69,7 +68,6 @@ int Timers::GetNumTimers(void)
   {
     m_iTimerCount = timerCount + 1;
   }
-  LOG_API_IRET(__FUNCTION__, timerCount);
   return m_iTimerCount;
 }
 
@@ -77,7 +75,6 @@ PVR_ERROR Timers::GetTimers(ADDON_HANDLE& handle)
 {
   std::string response;
   PVR_ERROR returnValue = PVR_ERROR_NO_ERROR;
-  LOG_API_CALL(__FUNCTION__);
   int timerCount = 0;
   // first add the recurring recordings
   if (m_request.DoRequest("/service?method=recording.recurring.list", response) == HTTP_OK)
@@ -253,8 +250,6 @@ PVR_ERROR Timers::GetTimers(ADDON_HANDLE& handle)
   {
     returnValue = PVR_ERROR_SERVER_ERROR;
   }
-
-  LOG_API_IRET(__FUNCTION__, returnValue);
   return returnValue;
 }
 
@@ -371,7 +366,6 @@ namespace
 
 PVR_ERROR Timers::GetTimerTypes(PVR_TIMER_TYPE types[], int* size)
 {
-  LOG_API_CALL(__FUNCTION__);
   static const int MSG_ONETIME_MANUAL = 30140;
   static const int MSG_ONETIME_GUIDE = 30141;
   static const int MSG_REPEATING_MANUAL = 30142;
@@ -626,7 +620,6 @@ PVR_ERROR Timers::AddTimer(const PVR_TIMER& timerinfo)
 {
 
   char preventDuplicates[16];
-  LOG_API_CALL(__FUNCTION__);
   if (timerinfo.iPreventDuplicateEpisodes)
     strcpy(preventDuplicates, "true");
   else
@@ -775,7 +768,6 @@ PVR_ERROR Timers::AddTimer(const PVR_TIMER& timerinfo)
 
 PVR_ERROR Timers::DeleteTimer(const PVR_TIMER& timer, bool bForceDelete)
 {
-  LOG_API_CALL(__FUNCTION__);
   std::string request = StringUtils::Format("/service?method=recording.delete&recording_id=%d", timer.iClientIndex);
 
   // handle recurring recordings
@@ -801,7 +793,5 @@ PVR_ERROR Timers::DeleteTimer(const PVR_TIMER& timer, bool bForceDelete)
 
 PVR_ERROR Timers::UpdateTimer(const PVR_TIMER& timerinfo)
 {
-  LOG_API_CALL(__FUNCTION__);
-  // not supported
   return AddTimer(timerinfo);
 }

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -1,0 +1,813 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "Timers.h"
+
+#include "kodi/util/XMLUtils.h"
+
+#include "pvrclient-nextpvr.h"
+
+#include <p8-platform/util/StringUtils.h>
+
+#if defined(TARGET_WINDOWS)
+#define atoll(S) _atoi64(S)
+#else
+#define MAXINT64 ULONG_MAX
+#endif
+
+using namespace NextPVR;
+
+/************************************************************/
+/** Timer handling */
+
+int Timers::GetNumTimers(void)
+{
+  LOG_API_CALL(__FUNCTION__);
+  // Return -1 in case of error.
+  if (m_iTimerCount != -1)
+    return m_iTimerCount;
+
+  std::string response;
+  int timerCount = -1;
+  // get list of recurring recordings
+  if (m_request.DoRequest("/service?method=recording.recurring.list", response) == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()) != NULL)
+    {
+      TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recurrings");
+      if (recordingsNode != NULL)
+      {
+        TiXmlElement* pRecordingNode;
+        for (pRecordingNode = recordingsNode->FirstChildElement("recurring"); pRecordingNode; pRecordingNode = pRecordingNode->NextSiblingElement())
+        {
+          timerCount++;
+        }
+      }
+    }
+  }
+
+
+  // get list of pending recordings
+  response = "";
+  if (m_request.DoRequest("/service?method=recording.list&filter=pending", response) == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()) != NULL)
+    {
+      TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
+      if (recordingsNode != NULL)
+      {
+        TiXmlElement* pRecordingNode;
+        for (pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode = pRecordingNode->NextSiblingElement())
+        {
+          timerCount++;
+        }
+      }
+    }
+  }
+  if (timerCount > -1)
+  {
+    m_iTimerCount = timerCount + 1;
+  }
+  LOG_API_IRET(__FUNCTION__, timerCount);
+  return m_iTimerCount;
+}
+
+PVR_ERROR Timers::GetTimers(ADDON_HANDLE& handle)
+{
+  std::string response;
+  PVR_ERROR returnValue = PVR_ERROR_NO_ERROR;
+  LOG_API_CALL(__FUNCTION__);
+  int timerCount = 0;
+  // first add the recurring recordings
+  if (m_request.DoRequest("/service?method=recording.recurring.list", response) == HTTP_OK)
+  {
+    TiXmlDocument doc;
+    if (doc.Parse(response.c_str()) != NULL)
+    {
+      PVR_TIMER tag;
+      TiXmlElement* recurringsNode = doc.RootElement()->FirstChildElement("recurrings");
+      TiXmlElement* pRecurringNode;
+      for (pRecurringNode = recurringsNode->FirstChildElement("recurring"); pRecurringNode; pRecurringNode = pRecurringNode->NextSiblingElement())
+      {
+        tag = {0};
+        TiXmlElement* pMatchRulesNode = pRecurringNode->FirstChildElement("matchrules");
+        TiXmlElement* pRulesNode = pMatchRulesNode->FirstChildElement("Rules");
+
+        tag.iClientIndex = g_pvrclient->XmlGetUInt(pRecurringNode, "id");
+        tag.iClientChannelUid = g_pvrclient->XmlGetInt(pRecurringNode, "ChannelOID");
+
+        tag.iTimerType = pRulesNode->FirstChildElement("EPGTitle") ? TIMER_REPEATING_EPG : TIMER_REPEATING_MANUAL;
+
+        // start/end time
+
+        std::string buffer;
+        if (XMLUtils::GetString(pRulesNode, "StartTimeTicks", buffer))
+        {
+          tag.startTime = stoll(buffer);
+          if (tag.startTime < time(nullptr))
+          {
+            tag.startTime = 0;
+          }
+          else
+          {
+            if (XMLUtils::GetString(pRulesNode, "EndTimeTicks", buffer))
+              tag.endTime = stoll(buffer);
+          }
+        }
+
+        // keyword recordings
+        std::string advancedRulesText;
+        if (XMLUtils::GetString(pRulesNode, "AdvancedRules", advancedRulesText))
+        {
+          if (advancedRulesText.find("KEYWORD: ") != std::string::npos)
+          {
+            tag.iTimerType = TIMER_REPEATING_KEYWORD;
+            tag.startTime = 0;
+            tag.endTime = 0;
+            tag.bStartAnyTime = true;
+            tag.bEndAnyTime = true;
+            strncpy(tag.strEpgSearchString, &advancedRulesText.c_str()[9], sizeof(tag.strEpgSearchString) - 1);
+          }
+          else
+          {
+            tag.iTimerType = TIMER_REPEATING_ADVANCED;
+            tag.startTime = 0;
+            tag.endTime = 0;
+            tag.bStartAnyTime = true;
+            tag.bEndAnyTime = true;
+            tag.bFullTextEpgSearch = true;
+            strncpy(tag.strEpgSearchString, advancedRulesText.c_str(), sizeof(tag.strEpgSearchString) - 1);
+          }
+
+        }
+
+        // days
+        tag.iWeekdays = PVR_WEEKDAY_ALLDAYS;
+        std::string daysText;
+        if (XMLUtils::GetString(pRulesNode, "Days", daysText))
+        {
+          tag.iWeekdays = PVR_WEEKDAY_NONE;
+          if (daysText.find("SUN") != std::string::npos)
+            tag.iWeekdays |= PVR_WEEKDAY_SUNDAY;
+          if (daysText.find("MON") != std::string::npos)
+            tag.iWeekdays |= PVR_WEEKDAY_MONDAY;
+          if (daysText.find("TUE") != std::string::npos)
+            tag.iWeekdays |= PVR_WEEKDAY_TUESDAY;
+          if (daysText.find("WED") != std::string::npos)
+            tag.iWeekdays |= PVR_WEEKDAY_WEDNESDAY;
+          if (daysText.find("THU") != std::string::npos)
+            tag.iWeekdays |= PVR_WEEKDAY_THURSDAY;
+          if (daysText.find("FRI") != std::string::npos)
+            tag.iWeekdays |= PVR_WEEKDAY_FRIDAY;
+          if (daysText.find("SAT") != std::string::npos)
+            tag.iWeekdays |= PVR_WEEKDAY_SATURDAY;
+        }
+
+        // pre/post padding
+        tag.iMarginStart = g_pvrclient->XmlGetUInt(pRecurringNode, "PrePadding");
+        tag.iMarginEnd = g_pvrclient->XmlGetUInt(pRecurringNode, "PostPadding");
+
+        // number of recordings to keep
+        tag.iMaxRecordings = g_pvrclient->XmlGetInt(pRecurringNode, "Keep");
+
+        // prevent duplicates
+        bool duplicate;
+        if (XMLUtils::GetBoolean(pRulesNode, "OnlyNewEpisodes", duplicate))
+        {
+          if (duplicate == true)
+          {
+            tag.iPreventDuplicateEpisodes = 1;
+          }
+        }
+
+        std::string recordingDirectoryID;
+        if (XMLUtils::GetString(pRulesNode, "RecordingDirectoryID", recordingDirectoryID))
+        {
+          int i = 0;
+          for (auto it = m_settings.m_recordingDirectories.begin(); it != m_settings.m_recordingDirectories.end(); ++it, i++)
+          {
+            std::string bracketed = "[" + m_settings.m_recordingDirectories[i] + "]";
+            if (bracketed == recordingDirectoryID)
+            {
+              tag.iRecordingGroup = i;
+              break;
+            }
+          }
+        }
+
+        buffer.clear();
+        XMLUtils::GetString(pRecurringNode, "name", buffer);
+        buffer.copy(tag.strTitle, sizeof(tag.strTitle) - 1);
+
+        tag.state = PVR_TIMER_STATE_SCHEDULED;
+
+        strcpy(tag.strSummary, "summary");
+
+        // pass timer to xbmc
+        timerCount++;
+        PVR->TransferTimerEntry(handle, &tag);
+      }
+    }
+    // next add the one-off recordings.
+    response = "";
+    if (m_request.DoRequest("/service?method=recording.list&filter=pending", response) == HTTP_OK)
+    {
+      TiXmlDocument doc;
+      if (doc.Parse(response.c_str()) != NULL)
+      {
+        PVR_TIMER tag;
+
+        TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
+        for (TiXmlElement* pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode = pRecordingNode->NextSiblingElement())
+        {
+          tag = {0};
+          UpdatePvrTimer(pRecordingNode, &tag);
+          // pass timer to xbmc
+          timerCount++;
+          PVR->TransferTimerEntry(handle, &tag);
+        }
+      }
+      response = "";
+      if (m_request.DoRequest("/service?method=recording.list&filter=conflict", response) == HTTP_OK)
+      {
+        TiXmlDocument doc;
+        if (doc.Parse(response.c_str()) != NULL)
+        {
+          PVR_TIMER tag;
+          TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
+          for (TiXmlElement* pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode = pRecordingNode->NextSiblingElement())
+          {
+            tag = {0};
+            UpdatePvrTimer(pRecordingNode, &tag);
+            // pass timer to xbmc
+            timerCount++;
+            PVR->TransferTimerEntry(handle, &tag);
+          }
+          m_iTimerCount = timerCount;
+        }
+      }
+    }
+  }
+  else
+  {
+    returnValue = PVR_ERROR_SERVER_ERROR;
+  }
+
+  LOG_API_IRET(__FUNCTION__, returnValue);
+  return returnValue;
+}
+
+bool Timers::UpdatePvrTimer(TiXmlElement* pRecordingNode, PVR_TIMER* tag)
+{
+  tag->iTimerType = pRecordingNode->FirstChildElement("epg_event_oid") ? TIMER_ONCE_EPG : TIMER_ONCE_MANUAL;
+
+  tag->iClientIndex = g_pvrclient->XmlGetUInt(pRecordingNode, "id");
+  tag->iClientChannelUid = g_pvrclient->XmlGetUInt(pRecordingNode, "channel_id");
+  tag->iParentClientIndex = g_pvrclient->XmlGetUInt(pRecordingNode, "recurring_parent", PVR_TIMER_NO_PARENT);
+
+  if (tag->iParentClientIndex != PVR_TIMER_NO_PARENT)
+  {
+    if (tag->iTimerType == TIMER_ONCE_EPG)
+      tag->iTimerType = TIMER_ONCE_EPG_CHILD;
+    else
+      tag->iTimerType = TIMER_ONCE_MANUAL_CHILD;
+  }
+  tag->iEpgUid = g_pvrclient->XmlGetUInt(pRecordingNode, "epg_event_oid", PVR_TIMER_NO_EPG_UID);
+  if (tag->iEpgUid != PVR_TIMER_NO_EPG_UID)
+  {
+    XBMC->Log(LOG_DEBUG, "Setting timer epg id %d %d", tag->iClientIndex, tag->iEpgUid);
+  }
+
+  tag->iMarginStart = g_pvrclient->XmlGetUInt(pRecordingNode, "pre_padding");
+  tag->iMarginEnd = g_pvrclient->XmlGetUInt(pRecordingNode, "post_padding");
+
+  std::string buffer;
+
+  // name
+  XMLUtils::GetString(pRecordingNode, "name", buffer);
+  buffer.copy(tag->strTitle, sizeof(tag->strTitle) - 1);
+
+  buffer.clear();
+  XMLUtils::GetString(pRecordingNode, "desc", buffer);
+  buffer.copy(tag->strSummary, sizeof(tag->strSummary) - 1);
+  // start/end time
+  buffer.clear();
+  XMLUtils::GetString(pRecordingNode, "start_time_ticks", buffer);
+  buffer.resize(10);
+  tag->startTime = std::stoll(buffer);
+  buffer.clear();
+  XMLUtils::GetString(pRecordingNode, "duration_seconds", buffer);
+  tag->endTime = tag->startTime + std::stoll(buffer);
+
+  tag->state = PVR_TIMER_STATE_SCHEDULED;
+
+  std::string status;
+  if (XMLUtils::GetString(pRecordingNode, "status", status))
+  {
+    if (status == "Recording" || (status == "Pending" && tag->startTime < time(nullptr) + m_settings.m_serverTimeOffset))
+    {
+      tag->state = PVR_TIMER_STATE_RECORDING;
+    }
+    else if (status == "Conflict")
+    {
+      tag->state = PVR_TIMER_STATE_CONFLICT_NOK;
+    }
+  }
+
+  return true;
+}
+
+namespace
+{
+  struct TimerType : PVR_TIMER_TYPE
+  {
+    TimerType(unsigned int id,
+              unsigned int attributes,
+              const std::string& description,
+              const std::vector<std::pair<int, std::string>>& maxRecordingsValues,
+              int maxRecordingsDefault,
+              const std::vector<std::pair<int, std::string>>& dupEpisodesValues,
+              int dupEpisodesDefault,
+              const std::vector<std::pair<int, std::string>>& recordingGroupsValues,
+              int recordingGroupDefault)
+    {
+      memset(this, 0, sizeof(PVR_TIMER_TYPE));
+
+      iId = id;
+      iAttributes = attributes;
+      iMaxRecordingsSize = static_cast<unsigned int>(maxRecordingsValues.size());
+      iMaxRecordingsDefault = maxRecordingsDefault;
+      iPreventDuplicateEpisodesSize = static_cast<unsigned int>(dupEpisodesValues.size());
+      iPreventDuplicateEpisodesDefault = dupEpisodesDefault;
+      iRecordingGroupSize = static_cast<unsigned int>(recordingGroupsValues.size());
+      iRecordingGroupDefault = recordingGroupDefault;
+      strncpy(strDescription, description.c_str(), sizeof(strDescription) - 1);
+
+      int i = 0;
+      for (auto it = maxRecordingsValues.begin(); it != maxRecordingsValues.end(); ++it, ++i)
+      {
+        maxRecordings[i].iValue = it->first;
+        strncpy(maxRecordings[i].strDescription, it->second.c_str(), sizeof(maxRecordings[i].strDescription) - 1);
+      }
+
+      i = 0;
+      for (auto it = dupEpisodesValues.begin(); it != dupEpisodesValues.end(); ++it, ++i)
+      {
+        preventDuplicateEpisodes[i].iValue = it->first;
+        strncpy(preventDuplicateEpisodes[i].strDescription, it->second.c_str(), sizeof(preventDuplicateEpisodes[i].strDescription) - 1);
+      }
+
+      i = 0;
+      for (auto it = recordingGroupsValues.begin(); it != recordingGroupsValues.end(); ++it, ++i)
+      {
+        recordingGroup[i].iValue = it->first;
+        strncpy(recordingGroup[i].strDescription, it->second.c_str(), sizeof(recordingGroup[i].strDescription) - 1);
+      }
+    }
+  };
+
+} // unnamed namespace
+
+PVR_ERROR Timers::GetTimerTypes(PVR_TIMER_TYPE types[], int* size)
+{
+  LOG_API_CALL(__FUNCTION__);
+  static const int MSG_ONETIME_MANUAL = 30140;
+  static const int MSG_ONETIME_GUIDE = 30141;
+  static const int MSG_REPEATING_MANUAL = 30142;
+  static const int MSG_REPEATING_GUIDE = 30143;
+  static const int MSG_REPEATING_CHILD = 30144;
+  static const int MSG_REPEATING_KEYWORD = 30145;
+  static const int MSG_REPEATING_ADVANCED = 30171;
+
+  static const int MSG_KEEPALL = 30150;
+  static const int MSG_KEEP1 = 30151;
+  static const int MSG_KEEP2 = 30152;
+  static const int MSG_KEEP3 = 30153;
+  static const int MSG_KEEP4 = 30154;
+  static const int MSG_KEEP5 = 30155;
+  static const int MSG_KEEP6 = 30156;
+  static const int MSG_KEEP7 = 30157;
+  static const int MSG_KEEP10 = 30158;
+
+  static const int MSG_SHOWTYPE_FIRSTRUNONLY = 30160;
+  static const int MSG_SHOWTYPE_ANY = 30161;
+
+  /* PVR_Timer.iMaxRecordings values and presentation. */
+  static std::vector<std::pair<int, std::string>> recordingLimitValues;
+  if (recordingLimitValues.size() == 0)
+  {
+    recordingLimitValues.emplace_back(std::make_pair(NEXTPVR_LIMIT_ASMANY, XBMC->GetLocalizedString(MSG_KEEPALL)));
+    recordingLimitValues.emplace_back(std::make_pair(NEXTPVR_LIMIT_1, XBMC->GetLocalizedString(MSG_KEEP1)));
+    recordingLimitValues.emplace_back(std::make_pair(NEXTPVR_LIMIT_2, XBMC->GetLocalizedString(MSG_KEEP2)));
+    recordingLimitValues.emplace_back(std::make_pair(NEXTPVR_LIMIT_3, XBMC->GetLocalizedString(MSG_KEEP3)));
+    recordingLimitValues.emplace_back(std::make_pair(NEXTPVR_LIMIT_4, XBMC->GetLocalizedString(MSG_KEEP4)));
+    recordingLimitValues.emplace_back(std::make_pair(NEXTPVR_LIMIT_5, XBMC->GetLocalizedString(MSG_KEEP5)));
+    recordingLimitValues.emplace_back(std::make_pair(NEXTPVR_LIMIT_6, XBMC->GetLocalizedString(MSG_KEEP6)));
+    recordingLimitValues.emplace_back(std::make_pair(NEXTPVR_LIMIT_7, XBMC->GetLocalizedString(MSG_KEEP7)));
+    recordingLimitValues.emplace_back(std::make_pair(NEXTPVR_LIMIT_10, XBMC->GetLocalizedString(MSG_KEEP10)));
+  }
+
+  /* PVR_Timer.iPreventDuplicateEpisodes values and presentation.*/
+  static std::vector<std::pair<int, std::string>> showTypeValues;
+  if (showTypeValues.size() == 0)
+  {
+    showTypeValues.emplace_back(std::make_pair(NEXTPVR_SHOWTYPE_FIRSTRUNONLY, XBMC->GetLocalizedString(MSG_SHOWTYPE_FIRSTRUNONLY)));
+    showTypeValues.emplace_back(std::make_pair(NEXTPVR_SHOWTYPE_ANY, XBMC->GetLocalizedString(MSG_SHOWTYPE_ANY)));
+  }
+
+  /* PVR_Timer.iRecordingGroup values and presentation */
+  int i = 0;
+  static std::vector<std::pair<int, std::string>> recordingGroupValues;
+  for (auto it = m_settings.m_recordingDirectories.begin(); it != m_settings.m_recordingDirectories.end(); ++it, i++)
+  {
+    recordingGroupValues.emplace_back(std::make_pair(i, m_settings.m_recordingDirectories[i]));
+  }
+
+  static const unsigned int TIMER_MANUAL_ATTRIBS
+    = PVR_TIMER_TYPE_IS_MANUAL |
+      PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+      PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+      PVR_TIMER_TYPE_SUPPORTS_END_TIME |
+      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
+      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN;
+
+  static const unsigned int TIMER_EPG_ATTRIBS
+    = PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+      PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
+      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN;
+
+  static const unsigned int TIMER_REPEATING_MANUAL_ATTRIBS
+    = PVR_TIMER_TYPE_IS_REPEATING |
+      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |
+      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
+      PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS |
+      PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS;
+
+  static const unsigned int TIMER_REPEATING_EPG_ATTRIBS
+    = PVR_TIMER_TYPE_IS_REPEATING |
+      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |
+      PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS |
+      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
+      PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES |
+      PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL |
+      PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS;
+
+  static const unsigned int TIMER_CHILD_ATTRIBUTES
+    = PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+      PVR_TIMER_TYPE_SUPPORTS_END_TIME |
+      PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES;
+
+  static const unsigned int TIMER_KEYWORD_ATTRIBS
+    = PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+      PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH |
+      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
+      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN;
+
+  static const unsigned int TIMER_REPEATING_KEYWORD_ATTRIBS
+      = PVR_TIMER_TYPE_IS_REPEATING |
+      PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES |
+      PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL |
+      PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS;
+
+  static const unsigned int TIMER_ADVANCED_ATTRIBS
+    = PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+      PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH  |
+      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
+      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN;
+
+
+
+  /* Timer types definition.*/
+  static std::vector<std::unique_ptr<TimerType>> timerTypes;
+  if (timerTypes.size() == 0)
+  {
+    timerTypes.emplace_back(
+        /* One-shot manual (time and channel based) */
+        std::unique_ptr<TimerType>(new TimerType(
+            /* Type id. */
+            TIMER_ONCE_MANUAL,
+            /* Attributes. */
+            TIMER_MANUAL_ATTRIBS,
+            /* Description. */
+            XBMC->GetLocalizedString(MSG_ONETIME_MANUAL), // "One time (manual)",
+            /* Values definitions for attributes. */
+            recordingLimitValues, m_defaultLimit, showTypeValues, m_defaultShowType, recordingGroupValues, 0)));
+
+    timerTypes.emplace_back(
+        /* One-shot epg based */
+        std::unique_ptr<TimerType>(new TimerType(
+            /* Type id. */
+            TIMER_ONCE_EPG,
+            /* Attributes. */
+            TIMER_EPG_ATTRIBS,
+            /* Description. */
+            XBMC->GetLocalizedString(MSG_ONETIME_GUIDE), // "One time (guide)",
+            /* Values definitions for attributes. */
+            recordingLimitValues, m_defaultLimit, showTypeValues, m_defaultShowType, recordingGroupValues, 0)));
+
+    timerTypes.emplace_back(
+        /* Repeating manual (time and channel based) Parent */
+        std::unique_ptr<TimerType>(new TimerType(
+            /* Type id. */
+            TIMER_REPEATING_MANUAL,
+            /* Attributes. */
+            TIMER_MANUAL_ATTRIBS | TIMER_REPEATING_MANUAL_ATTRIBS,
+            /* Description. */
+            XBMC->GetLocalizedString(MSG_REPEATING_MANUAL), // "Repeating (manual)"
+            /* Values definitions for attributes. */
+            recordingLimitValues, m_defaultLimit, showTypeValues, m_defaultShowType, recordingGroupValues, 0)));
+
+    timerTypes.emplace_back(
+        /* Repeating epg based Parent*/
+        std::unique_ptr<TimerType>(new TimerType(
+            /* Type id. */
+            TIMER_REPEATING_EPG,
+            /* Attributes. */
+            TIMER_EPG_ATTRIBS | TIMER_REPEATING_EPG_ATTRIBS,
+            /* Description. */
+            XBMC->GetLocalizedString(MSG_REPEATING_GUIDE), // "Repeating (guide)"
+            /* Values definitions for attributes. */
+            recordingLimitValues, m_defaultLimit, showTypeValues, m_defaultShowType, recordingGroupValues, 0)));
+
+    timerTypes.emplace_back(
+        /* Read-only one-shot for timers generated by timerec */
+        std::unique_ptr<TimerType>(new TimerType(
+            /* Type id. */
+            TIMER_ONCE_MANUAL_CHILD,
+            /* Attributes. */
+            TIMER_MANUAL_ATTRIBS | TIMER_CHILD_ATTRIBUTES,
+            /* Description. */
+            XBMC->GetLocalizedString(MSG_REPEATING_CHILD), // "Created by Repeating Timer"
+            /* Values definitions for attributes. */
+            recordingLimitValues, m_defaultLimit, showTypeValues, m_defaultShowType, recordingGroupValues, 0)));
+
+    timerTypes.emplace_back(
+        /* Read-only one-shot for timers generated by autorec */
+        std::unique_ptr<TimerType>(new TimerType(
+            /* Type id. */
+            TIMER_ONCE_EPG_CHILD,
+            /* Attributes. */
+            TIMER_EPG_ATTRIBS | TIMER_CHILD_ATTRIBUTES,
+            /* Description. */
+            XBMC->GetLocalizedString(MSG_REPEATING_CHILD), // "Created by Repeating Timer"
+            /* Values definitions for attributes. */
+            recordingLimitValues, m_defaultLimit, showTypeValues, m_defaultShowType, recordingGroupValues, 0)));
+
+    timerTypes.emplace_back(
+        /* Repeating epg based Parent*/
+        std::unique_ptr<TimerType>(new TimerType(
+            /* Type id. */
+            TIMER_REPEATING_KEYWORD,
+            /* Attributes. */
+            TIMER_KEYWORD_ATTRIBS | TIMER_REPEATING_KEYWORD_ATTRIBS,
+            /* Description. */
+            XBMC->GetLocalizedString(MSG_REPEATING_KEYWORD), // "Repeating (keyword)"
+            /* Values definitions for attributes. */
+            recordingLimitValues, m_defaultLimit, showTypeValues, m_defaultShowType, recordingGroupValues, 0)));
+
+    timerTypes.emplace_back(
+        /* Repeating epg based Parent*/
+        std::unique_ptr<TimerType>(new TimerType(
+            /* Type id. */
+            TIMER_REPEATING_ADVANCED,
+            /* Attributes. */
+            TIMER_ADVANCED_ATTRIBS | TIMER_REPEATING_KEYWORD_ATTRIBS,
+            /* Description. */
+            XBMC->GetLocalizedString(MSG_REPEATING_ADVANCED), // "Repeating (advanced)"
+            /* Values definitions for attributes. */
+            recordingLimitValues, m_defaultLimit, showTypeValues, m_defaultShowType, recordingGroupValues, 0)));
+  }
+
+  /* Copy data to target array. */
+  i = 0;
+  for (auto it = timerTypes.begin(); it != timerTypes.end(); ++it, ++i)
+    types[i] = **it;
+
+  *size = static_cast<int>(timerTypes.size());
+
+  return PVR_ERROR_NO_ERROR;
+}
+
+std::string Timers::GetDayString(int dayMask)
+{
+  std::string days;
+  if (dayMask == (PVR_WEEKDAY_SATURDAY | PVR_WEEKDAY_SUNDAY))
+  {
+    days = "WEEKENDS";
+  }
+  else if (dayMask == (PVR_WEEKDAY_MONDAY | PVR_WEEKDAY_TUESDAY | PVR_WEEKDAY_WEDNESDAY | PVR_WEEKDAY_THURSDAY | PVR_WEEKDAY_FRIDAY))
+  {
+    days = "WEEKDAYS";
+  }
+  else
+  {
+    if (dayMask & PVR_WEEKDAY_SATURDAY)
+      days += "SAT:";
+    if (dayMask & PVR_WEEKDAY_SUNDAY)
+      days += "SUN:";
+    if (dayMask & PVR_WEEKDAY_MONDAY)
+      days += "MON:";
+    if (dayMask & PVR_WEEKDAY_TUESDAY)
+      days += "TUE:";
+    if (dayMask & PVR_WEEKDAY_WEDNESDAY)
+      days += "WED:";
+    if (dayMask & PVR_WEEKDAY_THURSDAY)
+      days += "THU:";
+    if (dayMask & PVR_WEEKDAY_FRIDAY)
+      days += "FRI:";
+  }
+
+  return days;
+}
+
+PVR_ERROR Timers::AddTimer(const PVR_TIMER& timerinfo)
+{
+
+  char preventDuplicates[16];
+  LOG_API_CALL(__FUNCTION__);
+  if (timerinfo.iPreventDuplicateEpisodes)
+    strcpy(preventDuplicates, "true");
+  else
+    strcpy(preventDuplicates, "false");
+
+  const std::string encodedName = UriEncode(timerinfo.strTitle);
+  const std::string encodedKeyword = UriEncode(timerinfo.strEpgSearchString);
+  const std::string days = GetDayString(timerinfo.iWeekdays);
+  const std::string directory = UriEncode(m_settings.m_recordingDirectories[timerinfo.iRecordingGroup]);
+  const std::string oidKey = std::to_string(timerinfo.iEpgUid) + ":" + std::to_string(timerinfo.iClientChannelUid);
+  const int epgOid = m_epgOidLookup[oidKey];
+  XBMC->Log(LOG_DEBUG, "TIMER_%d %s", epgOid, oidKey.c_str());
+  std::string request;
+  switch (timerinfo.iTimerType)
+  {
+  case TIMER_ONCE_MANUAL:
+    XBMC->Log(LOG_DEBUG, "TIMER_ONCE_MANUAL");
+    // build one-off recording request
+    request = StringUtils::Format("/service?method=recording.save&name=%s&channel=%d&time_t=%d&duration=%d&pre_padding=%d&post_padding=%d&directory_id=%s",
+      encodedName.c_str(),
+      timerinfo.iClientChannelUid,
+      (int)timerinfo.startTime,
+      (int)(timerinfo.endTime - timerinfo.startTime),
+      (int)timerinfo.iMarginStart,
+      (int)timerinfo.iMarginEnd,
+      directory.c_str()
+      );
+    break;
+
+  case TIMER_ONCE_EPG:
+    XBMC->Log(LOG_DEBUG, "TIMER_ONCE_EPG");
+    // build one-off recording request
+    request = StringUtils::Format("/service?method=recording.save&recording_id=%d&event_id=%d&pre_padding=%d&post_padding=%d&directory_id=%s",
+      timerinfo.iClientIndex,
+      epgOid,
+      (int)timerinfo.iMarginStart,
+      (int)timerinfo.iMarginEnd,
+      directory.c_str());
+    break;
+
+  case TIMER_REPEATING_EPG:
+    if (timerinfo.iClientChannelUid == PVR_TIMER_ANY_CHANNEL)
+    {
+      // Fake a manual recording
+      XBMC->Log(LOG_DEBUG, "TIMER_REPEATING_EPG ANY CHANNEL");
+      std::string title = encodedName + "%";
+      request = StringUtils::Format("/service?method=recording.recurring.save&name=%s&channel_id=%d&start_time=%d&end_time=%d&keep=%d&pre_padding=%d&post_padding=%d&day_mask=%s&directory_id=%s,&keyword=%s",
+        encodedName.c_str(),
+        timerinfo.iClientChannelUid,
+        (int)timerinfo.startTime,
+        (int)timerinfo.endTime,
+        (int)timerinfo.iMaxRecordings,
+        (int)timerinfo.iMarginStart,
+        (int)timerinfo.iMarginEnd,
+        days.c_str(),
+        directory.c_str(),
+        title.c_str()
+        );
+    }
+    else
+    {
+      XBMC->Log(LOG_DEBUG, "TIMER_REPEATING_EPG");
+      // build recurring recording request
+      request = StringUtils::Format("/service?method=recording.recurring.save&recurring_id=%d&event_id=%d&keep=%d&pre_padding=%d&post_padding=%d&day_mask=%s&directory_id=%s&only_new=%s",
+        timerinfo.iClientIndex,
+        epgOid,
+        (int)timerinfo.iMaxRecordings,
+        (int)timerinfo.iMarginStart,
+        (int)timerinfo.iMarginEnd,
+        days.c_str(),
+        directory.c_str(),
+        preventDuplicates
+        );
+    }
+    break;
+
+  case TIMER_REPEATING_MANUAL:
+    XBMC->Log(LOG_DEBUG, "TIMER_REPEATING_MANUAL");
+    // build manual recurring request
+    request = StringUtils::Format("/service?method=recording.recurring.save&recurring_id=%d&name=%s&channel_id=%d&start_time=%d&end_time=%d&keep=%d&pre_padding=%d&post_padding=%d&day_mask=%s&directory_id=%s",
+      timerinfo.iClientIndex,
+      encodedName.c_str(),
+      timerinfo.iClientChannelUid,
+      (int)timerinfo.startTime,
+      (int)timerinfo.endTime,
+      (int)timerinfo.iMaxRecordings,
+      (int)timerinfo.iMarginStart,
+      (int)timerinfo.iMarginEnd,
+      days.c_str(),
+      directory.c_str()
+      );
+    break;
+
+  case TIMER_REPEATING_KEYWORD:
+    XBMC->Log(LOG_DEBUG, "TIMER_REPEATING_KEYWORD");
+    // build manual recurring request
+    request = StringUtils::Format("/service?method=recording.recurring.save&recurring_id=%d&name=%s&channel_id=%d&start_time=%d&end_time=%d&keep=%d&pre_padding=%d&post_padding=%d&directory_id=%s&keyword=%s&only_new=%s",
+      timerinfo.iClientIndex,
+      encodedName.c_str(),
+      timerinfo.iClientChannelUid,
+      (int)timerinfo.startTime,
+      (int)timerinfo.endTime,
+      (int)timerinfo.iMaxRecordings,
+      (int)timerinfo.iMarginStart,
+      (int)timerinfo.iMarginEnd,
+      directory.c_str(),
+      encodedKeyword.c_str(),
+      preventDuplicates
+      );
+    break;
+
+  case TIMER_REPEATING_ADVANCED:
+    XBMC->Log(LOG_DEBUG, "TIMER_REPEATING_ADVANCED");
+    // build manual advanced recurring request
+    request = StringUtils::Format("/service?method=recording.recurring.save&recurring_type=advanced&recurring_id=%d&name=%s&channel_id=%d&start_time=%d&end_time=%d&keep=%d&pre_padding=%d&post_padding=%d&directory_id=%s&advanced=%s&only_new=%s",
+      timerinfo.iClientIndex,
+      encodedName.c_str(),
+      timerinfo.iClientChannelUid,
+      (int)timerinfo.startTime,
+      (int)timerinfo.endTime,
+      (int)timerinfo.iMaxRecordings,
+      (int)timerinfo.iMarginStart,
+      (int)timerinfo.iMarginEnd,
+      directory.c_str(),
+      encodedKeyword.c_str(),
+      preventDuplicates
+      );
+    break;
+  }
+
+  // send request to NextPVR
+  std::string response;
+  if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
+  {
+    if (strstr(response.c_str(), "<rsp stat=\"ok\">"))
+    {
+      if (timerinfo.startTime <= time(nullptr) && timerinfo.endTime > time(nullptr))
+        PVR->TriggerRecordingUpdate();
+      PVR->TriggerTimerUpdate();
+      return PVR_ERROR_NO_ERROR;
+    }
+  }
+
+  return PVR_ERROR_FAILED;
+}
+
+PVR_ERROR Timers::DeleteTimer(const PVR_TIMER& timer, bool bForceDelete)
+{
+  LOG_API_CALL(__FUNCTION__);
+  std::string request = StringUtils::Format("/service?method=recording.delete&recording_id=%d", timer.iClientIndex);
+
+  // handle recurring recordings
+  if (timer.iTimerType >= TIMER_REPEATING_MIN && timer.iTimerType <= TIMER_REPEATING_MAX)
+  {
+    request = StringUtils::Format("/service?method=recording.recurring.delete&recurring_id=%d", timer.iClientIndex);
+  }
+
+  std::string response;
+  if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
+  {
+    if (strstr(response.c_str(), "<rsp stat=\"ok\">"))
+    {
+      PVR->TriggerTimerUpdate();
+      if (timer.startTime <= time(nullptr) && timer.endTime > time(nullptr))
+        PVR->TriggerRecordingUpdate();
+      return PVR_ERROR_NO_ERROR;
+    }
+  }
+
+  return PVR_ERROR_FAILED;
+}
+
+PVR_ERROR Timers::UpdateTimer(const PVR_TIMER& timerinfo)
+{
+  LOG_API_CALL(__FUNCTION__);
+  // not supported
+  return AddTimer(timerinfo);
+}

--- a/src/Timers.h
+++ b/src/Timers.h
@@ -16,25 +16,25 @@ using namespace ADDON;
 
 namespace NextPVR
 {
+  /* timer type ids */
+  constexpr unsigned int TIMER_MANUAL_MIN = PVR_TIMER_TYPE_NONE + 1;
+  constexpr unsigned int TIMER_ONCE_MANUAL = TIMER_MANUAL_MIN;
+  constexpr unsigned int TIMER_ONCE_EPG = TIMER_MANUAL_MIN + 1;
+  constexpr unsigned int TIMER_ONCE_KEYWORD = TIMER_MANUAL_MIN + 2;
+  constexpr unsigned int TIMER_ONCE_MANUAL_CHILD = TIMER_MANUAL_MIN + 3;
+  constexpr unsigned int TIMER_ONCE_EPG_CHILD = TIMER_MANUAL_MIN + 4;
+  constexpr unsigned int TIMER_ONCE_KEYWORD_CHILD =TIMER_MANUAL_MIN + 5;
+  constexpr unsigned int TIMER_MANUAL_MAX = TIMER_MANUAL_MIN + 5;
+
+  constexpr unsigned int TIMER_REPEATING_MIN = TIMER_MANUAL_MAX + 1;
+  constexpr unsigned int TIMER_REPEATING_MANUAL = TIMER_REPEATING_MIN;
+  constexpr unsigned int TIMER_REPEATING_EPG = TIMER_REPEATING_MIN + 1;
+  constexpr unsigned int TIMER_REPEATING_KEYWORD = TIMER_REPEATING_MIN + 2;
+  constexpr unsigned int TIMER_REPEATING_ADVANCED = TIMER_REPEATING_MIN + 3;
+  constexpr unsigned int TIMER_REPEATING_MAX = TIMER_REPEATING_MIN + 3;
+
   class Timers
   {
-    /* timer type ids */
-    #define TIMER_MANUAL_MIN (PVR_TIMER_TYPE_NONE + 1)
-    #define TIMER_ONCE_MANUAL (TIMER_MANUAL_MIN + 0)
-    #define TIMER_ONCE_EPG (TIMER_MANUAL_MIN + 1)
-    #define TIMER_ONCE_KEYWORD (TIMER_MANUAL_MIN + 2)
-    #define TIMER_ONCE_MANUAL_CHILD (TIMER_MANUAL_MIN + 3)
-    #define TIMER_ONCE_EPG_CHILD (TIMER_MANUAL_MIN + 4)
-    #define TIMER_ONCE_KEYWORD_CHILD (TIMER_MANUAL_MIN + 5)
-    #define TIMER_MANUAL_MAX (TIMER_MANUAL_MIN + 5)
-
-    #define TIMER_REPEATING_MIN (TIMER_MANUAL_MAX + 1)
-    #define TIMER_REPEATING_MANUAL (TIMER_REPEATING_MIN + 0)
-    #define TIMER_REPEATING_EPG (TIMER_REPEATING_MIN + 1)
-    #define TIMER_REPEATING_KEYWORD (TIMER_REPEATING_MIN + 2)
-    #define TIMER_REPEATING_ADVANCED (TIMER_REPEATING_MIN + 3)
-    #define TIMER_REPEATING_MAX (TIMER_REPEATING_MIN + 3)
-
     typedef enum
     {
       NEXTPVR_SHOWTYPE_ANY = 0,

--- a/src/Timers.h
+++ b/src/Timers.h
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+
+#pragma once
+
+#include "BackendRequest.h"
+#include "tinyxml.h"
+
+using namespace ADDON;
+
+namespace NextPVR
+{
+  class Timers
+  {
+    /* timer type ids */
+    #define TIMER_MANUAL_MIN (PVR_TIMER_TYPE_NONE + 1)
+    #define TIMER_ONCE_MANUAL (TIMER_MANUAL_MIN + 0)
+    #define TIMER_ONCE_EPG (TIMER_MANUAL_MIN + 1)
+    #define TIMER_ONCE_KEYWORD (TIMER_MANUAL_MIN + 2)
+    #define TIMER_ONCE_MANUAL_CHILD (TIMER_MANUAL_MIN + 3)
+    #define TIMER_ONCE_EPG_CHILD (TIMER_MANUAL_MIN + 4)
+    #define TIMER_ONCE_KEYWORD_CHILD (TIMER_MANUAL_MIN + 5)
+    #define TIMER_MANUAL_MAX (TIMER_MANUAL_MIN + 5)
+
+    #define TIMER_REPEATING_MIN (TIMER_MANUAL_MAX + 1)
+    #define TIMER_REPEATING_MANUAL (TIMER_REPEATING_MIN + 0)
+    #define TIMER_REPEATING_EPG (TIMER_REPEATING_MIN + 1)
+    #define TIMER_REPEATING_KEYWORD (TIMER_REPEATING_MIN + 2)
+    #define TIMER_REPEATING_ADVANCED (TIMER_REPEATING_MIN + 3)
+    #define TIMER_REPEATING_MAX (TIMER_REPEATING_MIN + 3)
+
+    typedef enum
+    {
+      NEXTPVR_SHOWTYPE_ANY = 0,
+      NEXTPVR_SHOWTYPE_FIRSTRUNONLY = 1,
+    } nextpvr_showtype_t;
+
+    typedef enum
+    {
+      NEXTPVR_LIMIT_ASMANY = 0,
+      NEXTPVR_LIMIT_1 = 1,
+      NEXTPVR_LIMIT_2 = 2,
+      NEXTPVR_LIMIT_3 = 3,
+      NEXTPVR_LIMIT_4 = 4,
+      NEXTPVR_LIMIT_5 = 5,
+      NEXTPVR_LIMIT_6 = 6,
+      NEXTPVR_LIMIT_7 = 7,
+      NEXTPVR_LIMIT_10 = 10
+    } nextpvr_recordinglimit_t;
+
+  public:
+    /**
+       * Singleton getter for the instance
+       */
+    static Timers& GetInstance()
+    {
+      static Timers timers;
+      return timers;
+    }
+
+    /* Timer handling */
+    int GetNumTimers(void);
+    PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int* size);
+    PVR_ERROR GetTimers(ADDON_HANDLE& handle);
+    PVR_ERROR AddTimer(const PVR_TIMER& timer);
+    PVR_ERROR DeleteTimer(const PVR_TIMER& timer, bool bForceDelete = false);
+    PVR_ERROR UpdateTimer(const PVR_TIMER& timer);
+    bool UpdatePvrTimer(TiXmlElement* pRecordingNode, PVR_TIMER* tag);
+    std::map<std::string, int> m_epgOidLookup;
+
+  private:
+    Timers() = default;
+
+    Timers(Timers const&) = delete;
+    void operator=(Timers const&) = delete;
+
+    Settings& m_settings = Settings::GetInstance();
+    Request& m_request = Request::GetInstance();
+
+    int m_defaultLimit = NEXTPVR_LIMIT_ASMANY;
+    int m_defaultShowType = NEXTPVR_SHOWTYPE_ANY;
+    int m_iTimerCount = -1;
+
+    std::string GetDayString(int dayMask);
+  };
+} // namespace NextPVR

--- a/src/buffers/ClientTimeshift.cpp
+++ b/src/buffers/ClientTimeshift.cpp
@@ -12,8 +12,6 @@
 #include "tinyxml.h"
 #include "kodi/util/XMLUtils.h"
 
-//#define FMODE 1
-
 using namespace timeshift;
 
 bool ClientTimeShift::Open(const std::string inputUrl, bool isRadio)
@@ -156,10 +154,10 @@ bool ClientTimeShift::GetStreamInfo()
   if (m_request.DoRequest("/services/service?method=channel.stream.info", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       TiXmlElement* filesNode = doc.FirstChildElement("map");
-      if (filesNode != NULL)
+      if (filesNode != nullptr)
       {
         stream_duration = strtoll(filesNode->FirstChildElement("stream_duration")->GetText(),nullptr,0);
         if (stream_duration != 0)

--- a/src/buffers/ClientTimeshift.h
+++ b/src/buffers/ClientTimeshift.h
@@ -13,7 +13,6 @@
 #include <thread>
 #include <list>
 
-std::string UriEncode(const std::string sSrc);
 using namespace NextPVR;
 using namespace ADDON;
 namespace timeshift {

--- a/src/buffers/RollingFile.cpp
+++ b/src/buffers/RollingFile.cpp
@@ -137,10 +137,10 @@ bool RollingFile::GetStreamInfo()
   if (m_request.DoRequest("/services/service?method=channel.stream.info", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       TiXmlElement* filesNode = doc.FirstChildElement("Files");
-      if (filesNode != NULL)
+      if (filesNode != nullptr)
       {
         stream_length = strtoll(filesNode->FirstChildElement("Length")->GetText(),nullptr,0);
         duration = strtoll(filesNode->FirstChildElement("Duration")->GetText(),nullptr,0);

--- a/src/buffers/RollingFile.cpp
+++ b/src/buffers/RollingFile.cpp
@@ -99,21 +99,20 @@ bool RollingFile::RollingFileOpen()
   recording.iDuration = 5 * 60 * 60;
   memset(recording.strDirectory,0,sizeof(recording.strDirectory));
   #if !defined(TESTURL)
-    strcpy(recording.strDirectory, m_activeFilename.c_str());
+  strcpy(recording.strDirectory, m_activeFilename.c_str());
   #endif
 
-  char strURL[1024];
   #if defined(TESTURL)
-    strcpy(strURL,TESTURL);
+  const std::string URL = TESTURL;
   #else
-    snprintf(strURL,sizeof(strURL),"http://%s:%d/stream?f=%s&mode=http&sid=%s", m_settings.m_hostname.c_str(), m_settings.m_port, UriEncode(m_activeFilename).c_str(), m_request.getSID());
-    if (m_isRadio && m_activeLength == -1)
-    {
-      // reduce buffer for radio when playing in-progess slip file
-      strcat(strURL,"&bufsize=32768&wait=true");
-    }
+  std::string URL = StringUtils::Format("http://%s:%d/stream?f=%s&mode=http&sid=%s", m_settings.m_hostname.c_str(), m_settings.m_port, UriEncode(m_activeFilename).c_str(), m_request.getSID());
+  if (m_isRadio && m_activeLength == -1)
+  {
+    // reduce buffer for radio when playing in-progess slip file
+    URL += "&bufsize=32768&wait=true";
+  }
   #endif
-  return RecordingBuffer::Open(strURL,recording);
+  return RecordingBuffer::Open(URL.c_str(),recording);
 }
 
 bool RollingFile::GetStreamInfo()

--- a/src/buffers/RollingFile.h
+++ b/src/buffers/RollingFile.h
@@ -14,8 +14,6 @@
 #include <mutex>
 #include <list>
 
-std::string UriEncode(const std::string sSrc);
-
 using namespace ADDON;
 namespace timeshift {
 

--- a/src/buffers/TranscodedBuffer.cpp
+++ b/src/buffers/TranscodedBuffer.cpp
@@ -78,10 +78,10 @@ int TranscodedBuffer::TranscodeStatus()
   if (m_request.DoRequest("/services/service?method=channel.transcode.status", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       TiXmlElement* rspNode = doc.FirstChildElement("rsp");
-      if (rspNode != NULL)
+      if (rspNode != nullptr)
       {
         bool final;
         XMLUtils::GetInt(rspNode,"percentage",percentage);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -13,23 +13,19 @@
 using namespace ADDON;
 using namespace NextPVR;
 
-#define PVR_MIN_API_VERSION "1.2.0"
-
 /* User adjustable settings are saved here.
  * Default values are defined inside client.h
  * and exported to the other source files.
  */
 
 /* Client member variables */
-ADDON_STATUS           m_CurStatus    = ADDON_STATUS_UNKNOWN;
-cPVRClientNextPVR     *g_pvrclient       = nullptr;
-std::string            g_szUserPath   = "";
-std::string            g_szClientPath = "";
+ADDON_STATUS m_CurStatus = ADDON_STATUS_UNKNOWN;
+cPVRClientNextPVR *g_pvrclient = nullptr;
 
 Settings& settings = Settings::GetInstance();
 
-CHelper_libXBMC_addon *XBMC           = NULL;
-CHelper_libXBMC_pvr   *PVR            = NULL;
+CHelper_libXBMC_addon *XBMC = nullptr;
+CHelper_libXBMC_pvr *PVR = nullptr;
 
 extern "C" {
 
@@ -68,8 +64,6 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   XBMC->Log(LOG_INFO, "Creating NextPVR PVR-Client");
 
   m_CurStatus    = ADDON_STATUS_UNKNOWN;
-  g_szUserPath   = pvrprops->strUserPath;
-  g_szClientPath = pvrprops->strClientPath;
 
   if (!XBMC->DirectoryExists("special://userdata/addon_data/pvr.nextpvr/"))
   {
@@ -80,7 +74,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   settings.ReadFromAddon();
 
   /* Create connection to NextPVR KODI TV client */
-  g_pvrclient = new cPVRClientNextPVR();
+  g_pvrclient       = new cPVRClientNextPVR();
   m_CurStatus = g_pvrclient->Connect();
 
   if (m_CurStatus != ADDON_STATUS_OK)
@@ -269,7 +263,7 @@ PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &it
   if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_pvrclient->CallMenuHook(menuhook, item);
+    return g_pvrclient->m_menuhook.CallMenuHook(menuhook, item);
 }
 
 
@@ -603,7 +597,7 @@ PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING& recording, int count)
 }
 
 /** UNUSED API FUNCTIONS */
-DemuxPacket* DemuxRead(void) { return NULL; }
+DemuxPacket* DemuxRead(void) { return nullptr; }
 void DemuxAbort(void) {}
 void DemuxReset(void) {}
 void DemuxFlush(void) {}

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -22,7 +22,7 @@ using namespace NextPVR;
 
 /* Client member variables */
 ADDON_STATUS           m_CurStatus    = ADDON_STATUS_UNKNOWN;
-cPVRClientNextPVR     *g_client       = nullptr;
+cPVRClientNextPVR     *g_pvrclient       = nullptr;
 std::string            g_szUserPath   = "";
 std::string            g_szClientPath = "";
 
@@ -80,12 +80,12 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   settings.ReadFromAddon();
 
   /* Create connection to NextPVR KODI TV client */
-  g_client       = new cPVRClientNextPVR();
-  m_CurStatus = g_client->Connect();
+  g_pvrclient = new cPVRClientNextPVR();
+  m_CurStatus = g_pvrclient->Connect();
 
   if (m_CurStatus != ADDON_STATUS_OK)
   {
-    SAFE_DELETE(g_client);
+    SAFE_DELETE(g_pvrclient);
     SAFE_DELETE(PVR);
     SAFE_DELETE(XBMC);
   }
@@ -99,7 +99,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
 //-----------------------------------------------------------------------------
 void ADDON_Destroy()
 {
-  SAFE_DELETE(g_client);
+  SAFE_DELETE(g_pvrclient);
   SAFE_DELETE(PVR);
   SAFE_DELETE(XBMC);
 
@@ -113,7 +113,7 @@ void ADDON_Destroy()
 ADDON_STATUS ADDON_GetStatus()
 {
   /* check whether we're still connected */
-  if (m_CurStatus == ADDON_STATUS_OK && g_client && !g_client->IsUp())
+  if (m_CurStatus == ADDON_STATUS_OK && g_pvrclient && !g_pvrclient->IsUp())
     m_CurStatus = ADDON_STATUS_LOST_CONNECTION;
 
   return m_CurStatus;
@@ -136,7 +136,7 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
   // SetSetting can occur when the addon is enabled, but TV support still
   // disabled. In that case the addon is not loaded, so we should not try
   // to change its settings.
-  if (!XBMC || !g_client)
+  if (!XBMC || !g_pvrclient)
     return ADDON_STATUS_OK;
 
   ADDON_STATUS status = settings.SetValue(settingName, settingValue);
@@ -144,7 +144,7 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
   {
     status = ADDON_STATUS_OK;
     // need to trigger recording update;
-    g_client->ForceRecordingUpdate();
+    g_pvrclient->ForceRecordingUpdate();
   }
 
   return status;
@@ -156,14 +156,14 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
 
 void OnSystemSleep()
 {
-  if (g_client)
-    g_client->OnSystemSleep();
+  if (g_pvrclient)
+    g_pvrclient->OnSystemSleep();
 }
 
 void OnSystemWake()
 {
-  if (g_client)
-    g_client->OnSystemWake();
+  if (g_pvrclient)
+    g_pvrclient->OnSystemWake();
 }
 
 void OnPowerSavingActivated()
@@ -212,8 +212,8 @@ PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES *pProperties)
 //-----------------------------------------------------------------------------
 const char * GetBackendName(void)
 {
-  if (g_client)
-    return g_client->GetBackendName();
+  if (g_pvrclient)
+    return g_pvrclient->GetBackendName();
   else
     return "";
 }
@@ -223,8 +223,8 @@ const char * GetBackendName(void)
 //-----------------------------------------------------------------------------
 const char * GetBackendVersion(void)
 {
-  if (g_client)
-    return g_client->GetBackendVersion();
+  if (g_pvrclient)
+    return g_pvrclient->GetBackendVersion();
   else
     return "";
 }
@@ -234,8 +234,8 @@ const char * GetBackendVersion(void)
 //-----------------------------------------------------------------------------
 const char * GetConnectionString(void)
 {
-  if (g_client)
-    return g_client->GetConnectionString();
+  if (g_pvrclient)
+    return g_pvrclient->GetConnectionString();
   else
     return "addon error!";
 }
@@ -253,10 +253,10 @@ const char * GetBackendHostname(void)
 //-----------------------------------------------------------------------------
 PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->GetDriveSpace(iTotal, iUsed);
+    return g_pvrclient->GetDriveSpace(iTotal, iUsed);
 }
 
 PVR_ERROR OpenDialogChannelScan()
@@ -266,10 +266,10 @@ PVR_ERROR OpenDialogChannelScan()
 
 PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->CallMenuHook(menuhook, item);
+    return g_pvrclient->CallMenuHook(menuhook, item);
 }
 
 
@@ -278,10 +278,10 @@ PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &it
 
 PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t iStart, time_t iEnd)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->GetEpg(handle, iChannelUid, iStart, iEnd);
+    return g_pvrclient->m_epg.GetEpg(handle, iChannelUid, iStart, iEnd);
 }
 
 
@@ -290,18 +290,18 @@ PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t iStart, 
 
 int GetChannelsAmount()
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return 0;
   else
-    return g_client->GetNumChannels();
+    return g_pvrclient->m_channels.GetNumChannels();
 }
 
 PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->GetChannels(handle, bRadio);
+    return g_pvrclient->m_channels.GetChannels(handle, bRadio);
 }
 
 PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel)
@@ -330,26 +330,26 @@ PVR_ERROR OpenDialogChannelAdd(const PVR_CHANNEL &channelinfo)
 
 int GetChannelGroupsAmount(void)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return 0;
   else
-    return g_client->GetChannelGroupsAmount();
+    return g_pvrclient->m_channels.GetChannelGroupsAmount();
 }
 
 PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->GetChannelGroups(handle, bRadio);
+    return g_pvrclient->m_channels.GetChannelGroups(handle, bRadio);
 }
 
 PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->GetChannelGroupMembers(handle, group);
+    return g_pvrclient->m_channels.GetChannelGroupMembers(handle, group);
 }
 
 
@@ -358,26 +358,26 @@ PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &g
 
 int GetRecordingsAmount(bool deleted)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return 0;
   else
-    return g_client->GetNumRecordings();
+    return g_pvrclient->m_recordings.GetNumRecordings();
 }
 
 PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->GetRecordings(handle);
+    return g_pvrclient->m_recordings.GetRecordings(handle);
 }
 
 PVR_ERROR DeleteRecording(const PVR_RECORDING &recording)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->DeleteRecording(recording);
+    return g_pvrclient->m_recordings.DeleteRecording(recording);
 }
 
 PVR_ERROR RenameRecording(const PVR_RECORDING &recording)
@@ -391,49 +391,49 @@ PVR_ERROR RenameRecording(const PVR_RECORDING &recording)
 
 PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
 {
-  if (g_client)
-    return g_client->GetTimerTypes(types, size);
+  if (g_pvrclient)
+    return g_pvrclient->m_timers.GetTimerTypes(types, size);
   return PVR_ERROR_SERVER_ERROR;
 }
 
 int GetTimersAmount(void)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return 0;
   else
-    return g_client->GetNumTimers();
+    return g_pvrclient->m_timers.GetNumTimers();
 }
 
 PVR_ERROR GetTimers(ADDON_HANDLE handle)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->GetTimers(handle);
+    return g_pvrclient->m_timers.GetTimers(handle);
 }
 
 PVR_ERROR AddTimer(const PVR_TIMER &timer)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->AddTimer(timer);
+    return g_pvrclient->m_timers.AddTimer(timer);
 }
 
 PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->DeleteTimer(timer, bForceDelete);
+    return g_pvrclient->m_timers.DeleteTimer(timer, bForceDelete);
 }
 
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->UpdateTimer(timer);
+    return g_pvrclient->m_timers.UpdateTimer(timer);
 }
 
 
@@ -442,54 +442,54 @@ PVR_ERROR UpdateTimer(const PVR_TIMER &timer)
 
 bool OpenLiveStream(const PVR_CHANNEL &channelinfo)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return false;
   else
-    return g_client->OpenLiveStream(channelinfo);
+    return g_pvrclient->OpenLiveStream(channelinfo);
 }
 
 void CloseLiveStream()
 {
-  if (g_client)
-    g_client->CloseLiveStream();
+  if (g_pvrclient)
+    g_pvrclient->CloseLiveStream();
 }
 
 int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return 0;
   else
-    return g_client->ReadLiveStream(pBuffer, iBufferSize);
+    return g_pvrclient->ReadLiveStream(pBuffer, iBufferSize);
 }
 
 long long SeekLiveStream(long long iPosition, int iWhence)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return -1;
   else
-    return g_client->SeekLiveStream(iPosition, iWhence);
+    return g_pvrclient->SeekLiveStream(iPosition, iWhence);
 }
 
 long long LengthLiveStream(void)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return -1;
   else
-    return g_client->LengthLiveStream();
+    return g_pvrclient->LengthLiveStream();
 }
 
 PVR_ERROR GetSignalStatus(int channelUid, PVR_SIGNAL_STATUS *signalStatus)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return PVR_ERROR_SERVER_ERROR;
   else
-    return g_client->GetSignalStatus(signalStatus);
+    return g_pvrclient->GetSignalStatus(signalStatus);
 }
 
 PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
 {
-  if (g_client)
-    return g_client->GetChannelStreamProperties(*channel,properties,iPropertiesCount);
+  if (g_pvrclient)
+    return g_pvrclient->GetChannelStreamProperties(*channel, properties, iPropertiesCount);
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
@@ -498,101 +498,101 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
 
 bool OpenRecordedStream(const PVR_RECORDING &recording)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return false;
   else
-    return g_client->OpenRecordedStream(recording);
+    return g_pvrclient->OpenRecordedStream(recording);
 }
 
 void CloseRecordedStream(void)
 {
-  if (g_client)
-    g_client->CloseRecordedStream();
+  if (g_pvrclient)
+    g_pvrclient->CloseRecordedStream();
 }
 
 int ReadRecordedStream(unsigned char *pBuffer, unsigned int iBufferSize)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return 0;
   else
-    return g_client->ReadRecordedStream(pBuffer, iBufferSize);
+    return g_pvrclient->ReadRecordedStream(pBuffer, iBufferSize);
 }
 
 long long SeekRecordedStream(long long iPosition, int iWhence)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return -1;
   else
-    return g_client->SeekRecordedStream(iPosition, iWhence);
+    return g_pvrclient->SeekRecordedStream(iPosition, iWhence);
 }
 
 long long LengthRecordedStream(void)
 {
-  if (!g_client)
+  if (!g_pvrclient)
     return -1;
   else
-    return g_client->LengthRecordedStream();
+    return g_pvrclient->LengthRecordedStream();
 }
 
 bool CanPauseStream(void)
 {
-  if (g_client)
-    return g_client->CanPauseStream();
+  if (g_pvrclient)
+    return g_pvrclient->CanPauseStream();
   return false;
 }
 
 void PauseStream(bool bPaused)
 {
-  if (g_client)
-    g_client->PauseStream(bPaused);
+  if (g_pvrclient)
+    g_pvrclient->PauseStream(bPaused);
 }
 
 bool CanSeekStream(void)
 {
-  if (g_client)
-    return g_client->CanPauseStream();
+  if (g_pvrclient)
+    return g_pvrclient->CanPauseStream();
   return false;
 }
 
 PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition)
 {
-  if (g_client)
-    return g_client->SetRecordingLastPlayedPosition(recording, lastplayedposition);
+  if (g_pvrclient)
+    return g_pvrclient->m_recordings.SetRecordingLastPlayedPosition(recording, lastplayedposition);
   return PVR_ERROR_SERVER_ERROR;
 }
 
 int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
 {
-  if (g_client)
-    return g_client->GetRecordingLastPlayedPosition(recording);
+  if (g_pvrclient)
+    return g_pvrclient->m_recordings.GetRecordingLastPlayedPosition(recording);
   return -1;
 }
 
 PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recording, PVR_EDL_ENTRY entries[], int *size)
 {
-  if (g_client)
-    return g_client->GetRecordingEdl(recording, entries, size);
+  if (g_pvrclient)
+    return g_pvrclient->m_recordings.GetRecordingEdl(recording, entries, size);
   return PVR_ERROR_SERVER_ERROR;
 }
 
 bool IsRealTimeStream(void)
 {
-  if (g_client)
-    return g_client->IsRealTimeStream();
+  if (g_pvrclient)
+    return g_pvrclient->IsRealTimeStream();
   return false;
 }
 
 PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *stimes)
 {
-  if (g_client)
-    return g_client->GetStreamTimes(stimes);
+  if (g_pvrclient)
+    return g_pvrclient->GetStreamTimes(stimes);
   return PVR_ERROR_SERVER_ERROR;
 }
 
 PVR_ERROR GetStreamReadChunkSize(int* chunksize)
 {
-  if (g_client)
-    return g_client->GetStreamReadChunkSize(chunksize);
+  if (g_pvrclient)
+    return g_pvrclient->GetStreamReadChunkSize(chunksize);
   return PVR_ERROR_SERVER_ERROR;
 }
 

--- a/src/client.h
+++ b/src/client.h
@@ -19,7 +19,7 @@ extern std::string      g_szClientPath;       ///< The Path where this driver is
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr          *PVR;
-extern class cPVRClientNextPVR *g_client;
+extern class cPVRClientNextPVR *g_pvrclient;
 
 typedef unsigned char byte;
 
@@ -30,5 +30,7 @@ typedef unsigned char byte;
  */
 #define PVR_STRCPY(dest, source) do { strncpy(dest, source, sizeof(dest)-1); dest[sizeof(dest)-1] = '\0'; } while(0)
 #define PVR_STRCLR(dest) memset(dest, 0, sizeof(dest))
+
+std::string UriEncode(const std::string sSrc);
 
 #endif /* CLIENT_H */

--- a/src/client.h
+++ b/src/client.h
@@ -14,9 +14,6 @@
 #include "kodi/libXBMC_addon.h"
 #include "kodi/libXBMC_pvr.h"
 
-extern std::string      g_szUserPath;         ///< The Path to the user directory inside user profile
-extern std::string      g_szClientPath;       ///< The Path where this driver is located
-
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr          *PVR;
 extern class cPVRClientNextPVR *g_pvrclient;
@@ -24,12 +21,6 @@ extern class cPVRClientNextPVR *g_pvrclient;
 typedef unsigned char byte;
 
 #define READ_NO_CACHE 0
-
-/*!
- * @brief PVR macros for string exchange
- */
-#define PVR_STRCPY(dest, source) do { strncpy(dest, source, sizeof(dest)-1); dest[sizeof(dest)-1] = '\0'; } while(0)
-#define PVR_STRCLR(dest) memset(dest, 0, sizeof(dest))
 
 std::string UriEncode(const std::string sSrc);
 

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -6,25 +6,24 @@
  *  See LICENSE.md for more information.
  */
 
-#include <ctime>
-#include <stdio.h>
-#include <stdlib.h>
-#include <regex>
-#include <memory>
-
-#include <p8-platform/util/StringUtils.h>
-#include "kodi/util/XMLUtils.h"
-
-#include "client.h"
 #include "pvrclient-nextpvr.h"
-#include "BackendRequest.h"
 
+#include "BackendRequest.h"
+#include "client.h"
+#include "kodi/util/XMLUtils.h"
 #include "md5.h"
 
+#include <ctime>
+#include <memory>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <p8-platform/util/StringUtils.h>
+
 #if defined(TARGET_WINDOWS)
-  #define atoll(S) _atoi64(S)
+#define atoll(S) _atoi64(S)
 #else
-  #define MAXINT64 ULONG_MAX
+#define MAXINT64 ULONG_MAX
 #endif
 
 #include <algorithm>
@@ -35,65 +34,56 @@ using namespace NextPVR;
 
 extern "C"
 {
-  ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue);
+  ADDON_STATUS ADDON_SetSetting(const char* settingName, const void* settingValue);
 }
 
 /* Globals */
 int g_iNextPVRXBMCBuild = 0;
 
 /* PVR client version (don't forget to update also the addon.xml and the Changelog.txt files) */
-#define PVRCLIENT_NEXTPVR_VERSION_STRING    "1.0.0.0"
-#define NEXTPVRC_MIN_VERSION_STRING         "4.2.4"
+#define PVRCLIENT_NEXTPVR_VERSION_STRING "1.0.0.0"
+#define NEXTPVRC_MIN_VERSION_STRING "4.2.4"
 
 #define DEBUGGING_XML 0
-#if DEBUGGING_XML
-void dump_to_log( TiXmlNode* pParent, unsigned int indent);
-#else
-#define dump_to_log(x, y)
-#endif
-
-
 #define DEBUGGING_API 0
 #if DEBUGGING_API
 #define LOG_API_CALL(f) XBMC->Log(LOG_INFO, "%s:  called!", f)
-#define LOG_API_IRET(f,i) XBMC->Log(LOG_INFO, "%s: returns %d", f, i)
+#define LOG_API_IRET(f, i) XBMC->Log(LOG_INFO, "%s: returns %d", f, i)
 #else
 #define LOG_API_CALL(f)
-#define LOG_API_IRET(f,i)
+#define LOG_API_IRET(f, i)
 #endif
 
-const char SAFE[256] =
-{
+const char SAFE[256] = {
     /*      0 1 2 3  4 5 6 7  8 9 A B  C D E F */
-    /* 0 */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
-    /* 1 */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
-    /* 2 */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
-    /* 3 */ 1,1,1,1, 1,1,1,1, 1,1,0,0, 0,0,0,0,
+    /* 0 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /* 1 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /* 2 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /* 3 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
 
-    /* 4 */ 0,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1,
-    /* 5 */ 1,1,1,1, 1,1,1,1, 1,1,1,0, 0,0,0,0,
-    /* 6 */ 0,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1,
-    /* 7 */ 1,1,1,1, 1,1,1,1, 1,1,1,0, 0,0,0,0,
+    /* 4 */ 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /* 5 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0,
+    /* 6 */ 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /* 7 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0,
 
-    /* 8 */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
-    /* 9 */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
-    /* A */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
-    /* B */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+    /* 8 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /* 9 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /* A */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /* B */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 
-    /* C */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
-    /* D */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
-    /* E */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
-    /* F */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0
-};
+    /* C */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /* D */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /* E */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /* F */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 std::string UriEncode(const std::string sSrc)
 {
   const char DEC2HEX[16 + 1] = "0123456789ABCDEF";
-  const unsigned char * pSrc = (const unsigned char *)sSrc.c_str();
+  const unsigned char* pSrc = (const unsigned char*)sSrc.c_str();
   const int SRC_LEN = sSrc.length();
-  unsigned char * const pStart = new unsigned char[SRC_LEN * 3];
-  unsigned char * pEnd = pStart;
-  const unsigned char * const SRC_END = pSrc + SRC_LEN;
+  unsigned char* const pStart = new unsigned char[SRC_LEN * 3];
+  unsigned char* pEnd = pStart;
+  const unsigned char* const SRC_END = pSrc + SRC_LEN;
 
   for (; pSrc < SRC_END; ++pSrc)
   {
@@ -110,8 +100,8 @@ std::string UriEncode(const std::string sSrc)
     }
   }
 
-  std::string sResult((char *)pStart, (char *)pEnd);
-  delete [] pStart;
+  std::string sResult((char*)pStart, (char*)pEnd);
+  delete[] pStart;
   return sResult;
 }
 
@@ -120,20 +110,11 @@ std::string UriEncode(const std::string sSrc)
 
 cPVRClientNextPVR::cPVRClientNextPVR()
 {
-  m_iCurrentChannel        = -1;
-  m_tcpclient              = new NextPVR::Socket(NextPVR::af_inet, NextPVR::pf_inet, NextPVR::sock_stream, NextPVR::tcp);
-  m_streamingclient        = new NextPVR::Socket(NextPVR::af_inet, NextPVR::pf_inet, NextPVR::sock_stream, NextPVR::tcp);
-  m_bConnected             = false;
-  m_currentRecordingLength = 0;
+  m_bConnected = false;
 
-  m_supportsLiveTimeshift  = false;
-  m_currentLiveLength      = 0;
-  m_currentLivePosition    = 0;
+  m_supportsLiveTimeshift = false;
 
-  m_defaultLimit = NEXTPVR_LIMIT_ASMANY;
-  m_defaultShowType = NEXTPVR_SHOWTYPE_ANY;
-
-  m_lastRecordingUpdateTime = MAXINT64;  // time of last recording check - force forever
+  m_lastRecordingUpdateTime = MAXINT64; // time of last recording check - force forever
   m_timeshiftBuffer = new timeshift::DummyBuffer();
   m_recordingBuffer = new timeshift::RecordingBuffer();
   m_realTimeBuffer = new timeshift::DummyBuffer();
@@ -149,30 +130,29 @@ cPVRClientNextPVR::~cPVRClientNextPVR()
   XBMC->Log(LOG_DEBUG, "->~cPVRClientNextPVR()");
   if (m_bConnected)
     Disconnect();
-  SAFE_DELETE(m_tcpclient);
   delete m_timeshiftBuffer;
   delete m_recordingBuffer;
   delete m_realTimeBuffer;
-  m_epgOidLookup.clear();
-  m_hostFilenames.clear();
-  m_channelDetails.clear();
-  m_liveStreams.clear();
+  m_timers.m_epgOidLookup.clear();
+  m_recordings.m_hostFilenames.clear();
+  m_epg.m_channelDetails.clear();
+  m_channels.m_liveStreams.clear();
 }
 
 PVR_ERROR cPVRClientNextPVR::CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA& item)
 {
   if (item.cat == PVR_MENUHOOK_CHANNEL && menuhook.iHookId == PVR_MENUHOOK_CHANNEL_DELETE_SINGLE_CHANNEL_ICON)
   {
-    DeleteChannelIcon(item.data.channel.iUniqueId);
+    m_channels.DeleteChannelIcon(item.data.channel.iUniqueId);
     PVR->TriggerChannelUpdate();
   }
   else if (item.cat == PVR_MENUHOOK_RECORDING && menuhook.iHookId == PVR_MENUHOOK_RECORDING_FORGET_RECORDING)
   {
-    ForgetRecording(item.data.recording);
+    m_recordings.ForgetRecording(item.data.recording);
   }
   else if (item.cat == PVR_MENUHOOK_SETTING && menuhook.iHookId == PVR_MENUHOOK_SETTING_DELETE_ALL_CHANNNEL_ICONS)
   {
-    DeleteChannelIcons();
+    m_channels.DeleteChannelIcons();
     PVR->TriggerChannelUpdate();
   }
   else if (item.cat == PVR_MENUHOOK_SETTING && menuhook.iHookId == PVR_MENUHOOK_SETTING_UPDATE_CHANNNELS)
@@ -181,7 +161,7 @@ PVR_ERROR cPVRClientNextPVR::CallMenuHook(const PVR_MENUHOOK& menuhook, const PV
   }
   else if (item.cat == PVR_MENUHOOK_SETTING && menuhook.iHookId == PVR_MENUHOOK_SETTING_UPDATE_CHANNNEL_GROUPS)
   {
-   PVR->TriggerChannelGroupsUpdate();
+    PVR->TriggerChannelGroupsUpdate();
   }
   return PVR_ERROR_NO_ERROR;
 }
@@ -189,25 +169,25 @@ PVR_ERROR cPVRClientNextPVR::CallMenuHook(const PVR_MENUHOOK& menuhook, const PV
 void cPVRClientNextPVR::ConfigureMenuhook()
 {
   PVR_MENUHOOK menuHook;
-  menuHook = { 0 };
+  menuHook = {0};
   menuHook.category = PVR_MENUHOOK_CHANNEL;
   menuHook.iHookId = PVR_MENUHOOK_CHANNEL_DELETE_SINGLE_CHANNEL_ICON;
   menuHook.iLocalizedStringId = 30183;
   PVR->AddMenuHook(&menuHook);
 
-  menuHook = { 0 };
+  menuHook = {0};
   menuHook.category = PVR_MENUHOOK_SETTING;
   menuHook.iHookId = PVR_MENUHOOK_SETTING_DELETE_ALL_CHANNNEL_ICONS;
   menuHook.iLocalizedStringId = 30170;
   PVR->AddMenuHook(&menuHook);
 
-  menuHook = { 0 };
+  menuHook = {0};
   menuHook.category = PVR_MENUHOOK_SETTING;
   menuHook.iHookId = PVR_MENUHOOK_SETTING_UPDATE_CHANNNELS;
   menuHook.iLocalizedStringId = 30185;
   PVR->AddMenuHook(&menuHook);
 
-  menuHook = { 0 };
+  menuHook = {0};
   menuHook.category = PVR_MENUHOOK_SETTING;
   menuHook.iHookId = PVR_MENUHOOK_SETTING_UPDATE_CHANNNEL_GROUPS;
   menuHook.iLocalizedStringId = 30186;
@@ -215,15 +195,13 @@ void cPVRClientNextPVR::ConfigureMenuhook()
 
   if (m_settings.m_backendVersion >= 50000)
   {
-    menuHook = { 0 };
+    menuHook = {0};
     menuHook.category = PVR_MENUHOOK_RECORDING;
     menuHook.iHookId = PVR_MENUHOOK_RECORDING_FORGET_RECORDING;
     menuHook.iLocalizedStringId = 30184;
     PVR->AddMenuHook(&menuHook);
   }
 }
-
-
 
 ADDON_STATUS cPVRClientNextPVR::Connect()
 {
@@ -234,28 +212,21 @@ ADDON_STATUS cPVRClientNextPVR::Connect()
   std::string response;
 
   SendWakeOnLan();
-  if (DoRequest("/service?method=session.initiate&ver=1.0&device=xbmc", response) == HTTP_OK)
+  if (m_request.DoRequest("/service?method=session.initiate&ver=1.0&device=xbmc", response) == HTTP_OK)
   {
     TiXmlDocument doc;
     if (doc.Parse(response.c_str()) != NULL)
     {
-      TiXmlElement* saltNode = doc.RootElement()->FirstChildElement("salt");
-      TiXmlElement* sidNode = doc.RootElement()->FirstChildElement("sid");
-
-      if (saltNode != NULL && sidNode != NULL)
+      std::string salt;
+      std::string sid;
+      if (XMLUtils::GetString(doc.RootElement(), "salt", salt) && XMLUtils::GetString(doc.RootElement(), "sid", sid))
       {
         // extract and store sid
-        PVR_STRCLR(m_sid);
-        PVR_STRCPY(m_sid, sidNode->FirstChild()->Value());
+        strcpy(m_sid, sid.c_str());
         m_request.setSID(m_sid);
-        // extract salt
-        char salt[64];
-        PVR_STRCLR(salt);
-        PVR_STRCPY(salt, saltNode->FirstChild()->Value());
 
         // a bit of debug
-        XBMC->Log(LOG_DEBUG, "session.initiate returns: sid=%s salt=%s", m_sid, salt);
-
+        XBMC->Log(LOG_DEBUG, "session.initiate returns: sid=%s salt=%s", m_sid, salt.c_str());
 
         std::string pinMD5 = PVRXBMC::XBMC_MD5::GetMD5(m_settings.m_PIN);
         StringUtils::ToLower(pinMD5);
@@ -272,11 +243,10 @@ ADDON_STATUS cPVRClientNextPVR::Connect()
 
         // login session
         std::string loginResponse;
-        char request[512];
-        sprintf(request, "/service?method=session.login&sid=%s&md5=%s", m_sid, md5.c_str());
-        if (DoRequest(request, loginResponse) == HTTP_OK)
+        std::string request = StringUtils::Format("/service?method=session.login&sid=%s&md5=%s", m_sid, md5.c_str());
+        if (m_request.DoRequest(request.c_str(), loginResponse) == HTTP_OK)
         {
-          if ( m_settings.ReadBackendSettings() == ADDON_STATUS_OK)
+          if (m_settings.ReadBackendSettings() == ADDON_STATUS_OK)
           {
             // set additional options based on the backend
             ConfigurePostConnectionOptions();
@@ -286,7 +256,7 @@ ADDON_STATUS cPVRClientNextPVR::Connect()
           }
           else
           {
-            PVR->ConnectionStateChange( "Version failure", PVR_CONNECTION_STATE_VERSION_MISMATCH, XBMC->GetLocalizedString(30050));
+            PVR->ConnectionStateChange("Version failure", PVR_CONNECTION_STATE_VERSION_MISMATCH, XBMC->GetLocalizedString(30050));
             m_bConnected = false;
             status = ADDON_STATUS_PERMANENT_FAILURE;
           }
@@ -294,7 +264,7 @@ ADDON_STATUS cPVRClientNextPVR::Connect()
         else
         {
           XBMC->Log(LOG_DEBUG, "session.login failed");
-          PVR->ConnectionStateChange( "Access denied", PVR_CONNECTION_STATE_ACCESS_DENIED, XBMC->GetLocalizedString(30052));
+          PVR->ConnectionStateChange("Access denied", PVR_CONNECTION_STATE_ACCESS_DENIED, XBMC->GetLocalizedString(30052));
           m_bConnected = false;
           status = ADDON_STATUS_LOST_CONNECTION;
         }
@@ -303,7 +273,7 @@ ADDON_STATUS cPVRClientNextPVR::Connect()
   }
   else
   {
-    PVR->ConnectionStateChange( "Could not connect to server", PVR_CONNECTION_STATE_SERVER_UNREACHABLE ,NULL);
+    PVR->ConnectionStateChange("Could not connect to server", PVR_CONNECTION_STATE_SERVER_UNREACHABLE, NULL);
     status = ADDON_STATUS_PERMANENT_FAILURE;
   }
 
@@ -317,7 +287,7 @@ void cPVRClientNextPVR::Disconnect()
   m_bConnected = false;
 }
 
-void cPVRClientNextPVR:: ConfigurePostConnectionOptions()
+void cPVRClientNextPVR::ConfigurePostConnectionOptions()
 {
   m_settings.SetVersionSpecificSettings();
   ConfigureMenuhook();
@@ -334,7 +304,7 @@ void cPVRClientNextPVR:: ConfigurePostConnectionOptions()
     {
       m_timeshiftBuffer = new timeshift::ClientTimeShift();
     }
-    else if ( m_settings.m_liveStreamingMethod != eStreamingMethod::Timeshift)
+    else if (m_settings.m_liveStreamingMethod != eStreamingMethod::Timeshift)
     {
       m_timeshiftBuffer = new timeshift::RollingFile();
     }
@@ -348,7 +318,7 @@ void cPVRClientNextPVR:: ConfigurePostConnectionOptions()
   if (XBMC->GetSetting("uselivestreams", &liveStreams))
   {
     if (liveStreams)
-      LoadLiveStreams();
+      m_channels.LoadLiveStreams();
   }
 
 }
@@ -361,13 +331,12 @@ bool cPVRClientNextPVR::IsUp()
 {
   LOG_API_CALL(__FUNCTION__);
   // check time since last time Recordings were updated, update if it has been awhile
-  if (m_bConnected == true && m_nowPlaying == NotPlaying && m_lastRecordingUpdateTime != MAXINT64 &&  time(0) > (m_lastRecordingUpdateTime + 60 ))
+  if (m_bConnected == true && m_nowPlaying == NotPlaying && m_lastRecordingUpdateTime != MAXINT64 && time(0) > (m_lastRecordingUpdateTime + 60))
   {
     TiXmlDocument doc;
-    char request[512];
-    sprintf(request, "/service?method=recording.lastupdated");
+    const std::string request = "/service?method=recording.lastupdated";
     std::string response;
-    if (DoRequest(request, response) == HTTP_OK)
+    if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
     {
       if (doc.Parse(response.c_str()) != NULL)
       {
@@ -399,7 +368,7 @@ bool cPVRClientNextPVR::IsUp()
   }
   else if (m_nowPlaying == Transcoding)
   {
-    if ( m_livePlayer->IsRealTimeStream() == false)
+    if (m_livePlayer->IsRealTimeStream() == false)
     {
       //m_livePlayer->Close();
       m_nowPlaying = NotPlaying;
@@ -409,7 +378,7 @@ bool cPVRClientNextPVR::IsUp()
   return m_bConnected;
 }
 
-void *cPVRClientNextPVR::Process(void)
+void* cPVRClientNextPVR::Process(void)
 {
   LOG_API_CALL(__FUNCTION__);
   while (!IsStopped())
@@ -424,44 +393,44 @@ void cPVRClientNextPVR::OnSystemSleep()
 {
   m_lastRecordingUpdateTime = MAXINT64;
   Disconnect();
-  PVR->ConnectionStateChange( "sleeping", PVR_CONNECTION_STATE_DISCONNECTED, NULL);
+  PVR->ConnectionStateChange("sleeping", PVR_CONNECTION_STATE_DISCONNECTED, NULL);
   Sleep(1000);
 }
 
 void cPVRClientNextPVR::OnSystemWake()
 {
-  PVR->ConnectionStateChange( "waking", PVR_CONNECTION_STATE_CONNECTING, NULL);
+  PVR->ConnectionStateChange("waking", PVR_CONNECTION_STATE_CONNECTING, NULL);
   int count = 0;
-  for (;count < 5; count++)
+  for (; count < 5; count++)
   {
     if (Connect())
     {
-      PVR->ConnectionStateChange( "connected", PVR_CONNECTION_STATE_CONNECTED, NULL);
+      PVR->ConnectionStateChange("connected", PVR_CONNECTION_STATE_CONNECTED, NULL);
       break;
     }
     Sleep(500);
   }
 
-  XBMC->Log(LOG_INFO, "On NextPVR Wake %d %d",m_bConnected, count);
+  XBMC->Log(LOG_INFO, "On NextPVR Wake %d %d", m_bConnected, count);
 }
 
 void cPVRClientNextPVR::SendWakeOnLan()
 {
-  if (m_settings.m_enableWOL == true )
+  if (m_settings.m_enableWOL == true)
   {
     if (m_settings.m_hostname == "127.0.0.1" || m_settings.m_hostname == "localhost" || m_settings.m_hostname == "::1")
     {
       return;
     }
     int count = 0;
-    for (;count < m_settings.m_timeoutWOL; count++)
+    for (; count < m_settings.m_timeoutWOL; count++)
     {
       if (m_request.PingBackend())
       {
         return;
       }
       XBMC->WakeOnLan(m_settings.m_hostMACAddress.c_str());
-      XBMC->Log(LOG_DEBUG, "WOL sent %d",count);
+      XBMC->Log(LOG_DEBUG, "WOL sent %d", count);
       Sleep(1000);
     }
   }
@@ -508,7 +477,7 @@ const char* cPVRClientNextPVR::GetConnectionString(void)
   return strConnectionString.c_str();
 }
 
-PVR_ERROR cPVRClientNextPVR::GetDriveSpace(long long *iTotal, long long *iUsed)
+PVR_ERROR cPVRClientNextPVR::GetDriveSpace(long long* iTotal, long long* iUsed)
 {
   LOG_API_CALL(__FUNCTION__);
   string result;
@@ -523,495 +492,45 @@ PVR_ERROR cPVRClientNextPVR::GetDriveSpace(long long *iTotal, long long *iUsed)
   return PVR_ERROR_NO_ERROR;
 }
 
-/************************************************************/
-/** EPG handling */
 
-PVR_ERROR cPVRClientNextPVR::GetEpg(ADDON_HANDLE handle, int iChannelUid, time_t iStart, time_t iEnd)
+int cPVRClientNextPVR::XmlGetInt(TiXmlElement* node, const char* name, const int setDefault)
 {
-  EPG_TAG broadcast;
-
-  std::string response;
-  char request[512];
-  LOG_API_CALL(__FUNCTION__);
-
-  pair<bool, bool> channelDetail;
-  channelDetail = m_channelDetails[iChannelUid];
-  if (channelDetail.first == true)
-  {
-    XBMC->Log(LOG_DEBUG, "Skipping %d", iChannelUid);
-    return PVR_ERROR_NO_ERROR;
-  }
-
-  if ( iEnd < (time(nullptr) - 24 * 3600))
-  {
-      XBMC->Log(LOG_DEBUG, "Skipping expired EPG data %d %ld %lld",iChannelUid,iStart, iEnd);
-      return PVR_ERROR_INVALID_PARAMETERS;
-  }
-  sprintf(request, "/service?method=channel.listings&channel_id=%d&start=%d&end=%d&genre=all", iChannelUid, static_cast<int>(iStart), static_cast<int>(iEnd));
-  if (DoRequest(request, response) == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      TiXmlElement* listingsNode = doc.RootElement()->FirstChildElement("listings");
-      TiXmlElement* pListingNode;
-      for( pListingNode = listingsNode->FirstChildElement("l"); pListingNode; pListingNode=pListingNode->NextSiblingElement())
-      {
-        broadcast = {};
-
-        string title;
-        string description;
-        string subtitle;
-        XMLUtils::GetString(pListingNode,"name",title);
-        XMLUtils::GetString(pListingNode,"description",description);
-
-        if (XMLUtils::GetString(pListingNode,"subtitle",subtitle))
-        {
-          if (description != subtitle + ":" && StringUtils::StartsWith(description,subtitle + ": "))
-          {
-            description = description.substr(subtitle.length()+2);
-          }
-        }
-
-        broadcast.iYear = XmlGetInt(pListingNode,"year");;
-
-        string startTime, endTime;
-        XMLUtils::GetString(pListingNode,"start",startTime);
-        startTime.resize(10);
-        XMLUtils::GetString(pListingNode,"end",endTime);
-        endTime.resize(10);
-
-        const std::string oidLookup(endTime + ":" + to_string(iChannelUid));
-
-        const int epgOid = XmlGetInt(pListingNode,"id");
-        m_epgOidLookup[oidLookup] = epgOid;
-
-        broadcast.strTitle            = title.c_str();
-        broadcast.strEpisodeName      = subtitle.c_str();
-        broadcast.iUniqueChannelId    = iChannelUid;
-        broadcast.startTime           = stol(startTime);
-        broadcast.iUniqueBroadcastId  = stoi(endTime);
-        broadcast.endTime             = stol(endTime);
-        broadcast.strPlotOutline      = NULL; //unused
-        broadcast.strPlot             = description.c_str();
-        broadcast.strOriginalTitle    = NULL; // unused
-        broadcast.strCast             = NULL; // unused
-        broadcast.strDirector         = NULL; // unused
-        broadcast.strWriter           = NULL; // unused
-        broadcast.strIMDBNumber       = NULL; // unused
-
-        std::string artworkPath;
-        if (m_settings.m_downloadGuideArtwork)
-        {
-          // artwork URL
-          if (m_settings.m_backendVersion < 50000)
-            artworkPath = StringUtils::Format("http://%s:%d/service?method=channel.show.artwork&sid=%s&event_id=%d", m_settings.m_hostname.c_str(), m_settings.m_port, m_sid, epgOid);
-          else
-          {
-            if (m_settings.m_sendSidWithMetadata)
-              artworkPath = StringUtils::Format("http://%s:%d/service?method=channel.show.artwork&sid=%s&name=%s", m_settings.m_hostname.c_str(), m_settings.m_port, m_sid,UriEncode(title).c_str());
-            else
-              artworkPath = StringUtils::Format("http://%s:%d/service?method=channel.show.artwork&name=%s", m_settings.m_hostname.c_str(), m_settings.m_port, UriEncode(title).c_str());
-            if (m_settings.m_guideArtPortrait)
-              artworkPath += "&prefer=poster";
-          }
-          broadcast.strIconPath = artworkPath.c_str();
-        }
-        std::string sGenre;
-        if (XMLUtils::GetString(pListingNode,"genre",sGenre))
-        {
-          broadcast.strGenreDescription = sGenre.c_str();
-          broadcast.iGenreType = EPG_GENRE_USE_STRING;
-        }
-        else
-        {
-          // genre type
-          broadcast.iGenreType = XmlGetInt(pListingNode,"genre_type");
-          broadcast.iGenreSubType = XmlGetInt(pListingNode,"genre_subtype");
-        }
-        if (pListingNode->FirstChildElement("genres") != NULL)
-        {
-          std::string allGenres;
-          if (GetAdditiveString(pListingNode->FirstChildElement("genres"), "genre", EPG_STRING_TOKEN_SEPARATOR, allGenres, true))
-          {
-            if (allGenres.find(EPG_STRING_TOKEN_SEPARATOR) != std::string::npos)
-            {
-              if (broadcast.iGenreType != EPG_GENRE_USE_STRING)
-              {
-                broadcast.iGenreSubType = EPG_GENRE_USE_STRING;
-              }
-              sGenre = allGenres;
-              broadcast.strGenreDescription = sGenre.c_str();
-            }
-          }
-        }
-        int value = 0;
-        XMLUtils::GetInt(pListingNode,"season",value);
-        if ( value == 0 )
-          broadcast.iSeriesNumber = EPG_TAG_INVALID_SERIES_EPISODE;
-        else
-          broadcast.iSeriesNumber = value;
-
-        value = 0;
-        XMLUtils::GetInt(pListingNode,"episode",value);
-        if ( value == 0 )
-          broadcast.iEpisodeNumber = EPG_TAG_INVALID_SERIES_EPISODE;
-        else
-          broadcast.iEpisodeNumber = value;
-
-        broadcast.iEpisodePartNumber = EPG_TAG_INVALID_SERIES_EPISODE;
-
-        std::string original;
-        XMLUtils::GetString(pListingNode,"original",original);
-        broadcast.strFirstAired = original.c_str();
-
-        bool firstrun;
-        if (XMLUtils::GetBoolean(pListingNode,"firstrun",firstrun))
-        {
-          if (firstrun)
-          {
-            std::string significance;
-            XMLUtils::GetString(pListingNode,"significance",significance);
-            if (significance == "Live")
-            {
-              broadcast.iFlags = EPG_TAG_FLAG_IS_LIVE;
-            }
-            else if (significance.find("Premiere") != string::npos)
-            {
-              broadcast.iFlags = EPG_TAG_FLAG_IS_PREMIERE;
-            }
-            else if (significance.find("Finale") != string::npos)
-            {
-              broadcast.iFlags = EPG_TAG_FLAG_IS_FINALE;
-            }
-            else if (m_settings.m_showNew)
-            {
-              broadcast.iFlags = EPG_TAG_FLAG_IS_NEW;
-            }
-          }
-        }
-        PVR->TransferEpgEntry(handle, &broadcast);
-      }
-    }
-  }
-
-  return PVR_ERROR_NO_ERROR;
-}
-
-int cPVRClientNextPVR::XmlGetInt(TiXmlElement * node, const char* name)
-{
-  int retval = 0;
-  XMLUtils::GetInt(node,name,retval);
+  int retval = setDefault;
+  XMLUtils::GetInt(node, name, retval);
   return retval;
 }
 
-
-/************************************************************/
-/** Channel handling */
-
-int cPVRClientNextPVR::GetNumChannels(void)
+unsigned int cPVRClientNextPVR::XmlGetUInt(TiXmlElement* node, const char* name, const unsigned int setDefault)
 {
-  LOG_API_CALL(__FUNCTION__);
-  // need something more optimal, but this will do for now...
-  std::string response;
-  int channelCount = 0;
-  if (DoRequest("/service?method=channel.list", response) == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      TiXmlElement* channelsNode = doc.RootElement()->FirstChildElement("channels");
-      TiXmlElement* pChannelNode;
-      for( pChannelNode = channelsNode->FirstChildElement("channel"); pChannelNode; pChannelNode=pChannelNode->NextSiblingElement())
-      {
-        channelCount++;
-      }
-    }
-  }
-
-  return channelCount;
+  unsigned int retval = setDefault;
+  XMLUtils::GetUInt(node, name, retval);
+  return retval;
 }
 
-std::string cPVRClientNextPVR::GetChannelIcon(int channelID)
-{
-  LOG_API_CALL(__FUNCTION__);
-
-  std::string iconFilename = GetChannelIconFileName(channelID);
-
-  // do we already have the icon file?
-  if (XBMC->FileExists(XBMC->TranslateSpecialProtocol(iconFilename.c_str()), false))
-  {
-    return iconFilename;
-  }
-  char strURL[256];
-  sprintf(strURL, "/service?method=channel.icon&channel_id=%d", channelID);
-  if (m_request.FileCopy(strURL, iconFilename) == HTTP_OK)
-  {
-    return iconFilename;
-  }
-
-  return "";
-}
-
-std::string cPVRClientNextPVR::GetChannelIconFileName(int channelID)
-{
-  char filename[64];
-  snprintf(filename, sizeof(filename), "nextpvr-ch%d.png", channelID);
-  const std::string iconFilePath("special://userdata/addon_data/pvr.nextpvr/");
-
-  return iconFilePath + filename;
-}
-
-void  cPVRClientNextPVR::DeleteChannelIcon(int channelID)
-{
-  #if defined(TARGET_WINDOWS)
-    #undef DeleteFile
-  #endif
-  XBMC->DeleteFile(GetChannelIconFileName(channelID).c_str());
-}
-
-void  cPVRClientNextPVR::DeleteChannelIcons()
-{
-  VFSDirEntry* icons;
-  unsigned int count;
-  if (XBMC->GetDirectory("special://userdata/addon_data/pvr.nextpvr/","nextpvr-ch*.png", &icons, &count))
-  {
-    XBMC->Log(LOG_INFO, "Deleting %d channel icons", count);
-    for (unsigned int i = 0; i < count; ++i)
-    {
-      VFSDirEntry& f = icons[i];
-      const std::string deleteme = f.path;
-      XBMC->Log(LOG_DEBUG,"DeleteFile %s rc:%d",XBMC->TranslateSpecialProtocol(f.path),remove(XBMC->TranslateSpecialProtocol(f.path)));
-    }
-  }
-}
-
-void cPVRClientNextPVR::LoadLiveStreams()
-{
-  char strURL[256];
-  sprintf(strURL, "/public/LiveStreams.xml");
-  m_liveStreams.clear();
-  if (m_request.FileCopy(strURL, "special://userdata/addon_data/pvr.nextpvr/LiveStreams.xml") == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    char *liveStreams = XBMC->TranslateSpecialProtocol("special://userdata/addon_data/pvr.nextpvr/LiveStreams.xml");
-    XBMC->Log(LOG_DEBUG, "Loading LiveStreams.xml %s", liveStreams);
-    if (doc.LoadFile(liveStreams))
-    {
-      TiXmlElement* streamsNode = doc.FirstChildElement("streams");
-      if (streamsNode)
-      {
-        TiXmlElement* streamNode;
-        for( streamNode = streamsNode->FirstChildElement("stream"); streamNode; streamNode=streamNode->NextSiblingElement())
-        {
-          std::string key_value;
-          if ( streamNode->QueryStringAttribute("id", &key_value)==TIXML_SUCCESS)
-          {
-            try {
-              if (streamNode->FirstChild())
-              {
-                int channelID = std::stoi(key_value);
-                XBMC->Log(LOG_DEBUG, "%d %s",channelID, streamNode->FirstChild()->Value());
-                m_liveStreams[channelID] = streamNode->FirstChild()->Value();
-              }
-            } catch (...)
-            {
-                XBMC->Log(LOG_DEBUG, "%s:%d",__FUNCTION__,__LINE__);
-            }
-          }
-        }
-      }
-      XBMC->FreeString(liveStreams);
-    }
-  }
-}
-
-PVR_ERROR cPVRClientNextPVR::GetChannels(ADDON_HANDLE handle, bool bRadio)
-{
-  PVR_CHANNEL     tag;
-  std::string      stream;
-  LOG_API_CALL(__FUNCTION__);
-
-  std::map<int, std::pair<bool, bool>>::iterator  itr = m_channelDetails.begin();
-  while (itr != m_channelDetails.end())
-  {
-    if (itr->second.second == (bRadio == true))
-      itr = m_channelDetails.erase(itr);
-    else
-      ++itr;
-  }
-
-  std::string response;
-  if (DoRequest("/service?method=channel.list&extras=true", response) == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      //XBMC->Log(LOG_INFO, "Channels:\n");
-      //dump_to_log(&doc, 0);
-      TiXmlElement* channelsNode = doc.RootElement()->FirstChildElement("channels");
-      TiXmlElement* pChannelNode;
-      for( pChannelNode = channelsNode->FirstChildElement("channel"); pChannelNode; pChannelNode=pChannelNode->NextSiblingElement())
-      {
-        memset(&tag, 0, sizeof(PVR_CHANNEL));
-        TiXmlElement* channelTypeNode = pChannelNode->FirstChildElement("type");
-        tag.iUniqueId = atoi(pChannelNode->FirstChildElement("id")->FirstChild()->Value());
-        if (strcmp(channelTypeNode->FirstChild()->Value(), "0xa") == 0)
-        {
-          tag.bIsRadio = true;
-          PVR_STRCPY(tag.strInputFormat, "application/octet-stream");
-        }
-        else
-        {
-          tag.bIsRadio = false;
-          if (!IsChannelAPlugin(tag.iUniqueId))
-            PVR_STRCPY(tag.strInputFormat, "video/MP2T");
-        }
-        if (bRadio != tag.bIsRadio)
-          continue;
-
-        tag.iChannelNumber = atoi(pChannelNode->FirstChildElement("number")->FirstChild()->Value());
-
-        // handle major.minor style subchannels
-        if (pChannelNode->FirstChildElement("minor"))
-        {
-          tag.iSubChannelNumber = atoi(pChannelNode->FirstChildElement("minor")->FirstChild()->Value());
-        }
-
-        PVR_STRCPY(tag.strChannelName, pChannelNode->FirstChildElement("name")->FirstChild()->Value());
-
-        // check if we need to download a channel icon
-        if (pChannelNode->FirstChildElement("icon"))
-        {
-          std::string iconFile = GetChannelIcon(tag.iUniqueId);
-          if (iconFile.length() > 0)
-          {
-            PVR_STRCPY(tag.strIconPath, iconFile.c_str());
-          }
-        }
-
-        // V5 has the EPG source type info.
-        string epg;
-        if (XMLUtils::GetString(pChannelNode, "epg", epg))
-          m_channelDetails[tag.iUniqueId] = make_pair(epg == "None", tag.bIsRadio);
-        else
-          m_channelDetails[tag.iUniqueId] = make_pair(false, tag.bIsRadio);
-
-        // transfer channel to XBMC
-        PVR->TransferChannelEntry(handle, &tag);
-      }
-    }
-  }
-  return PVR_ERROR_NO_ERROR;
-}
-
-/************************************************************/
-/** Channel group handling **/
-
-int cPVRClientNextPVR::GetChannelGroupsAmount(void)
-{
-  LOG_API_CALL(__FUNCTION__);
-  // Not directly possible at the moment
-  XBMC->Log(LOG_DEBUG, "GetChannelGroupsAmount");
-
-  int groups = 0;
-
-  std::string response;
-  if (DoRequest("/service?method=channel.groups", response) == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      TiXmlElement* groupsNode = doc.RootElement()->FirstChildElement("groups");
-      TiXmlElement* pGroupNode;
-      for( pGroupNode = groupsNode->FirstChildElement("group"); pGroupNode; pGroupNode=pGroupNode->NextSiblingElement())
-      {
-        groups++;
-      }
-    }
-  }
-
-  return groups;
-}
-
-PVR_RECORDING_CHANNEL_TYPE cPVRClientNextPVR::GetChannelType(unsigned int uid)
-{
-  // when uid is invalid we assume TV because Kodi will
-  if (m_channelDetails.count(uid) > 0 && m_channelDetails[uid].second == true)
-    return PVR_RECORDING_CHANNEL_TYPE_RADIO;
-
-  return PVR_RECORDING_CHANNEL_TYPE_TV;
-}
-
-PVR_ERROR cPVRClientNextPVR::GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
-{
-  PVR_CHANNEL_GROUP tag;
-  LOG_API_CALL(__FUNCTION__);
-
-  // nextpvr doesn't have a separate concept of radio channel groups
-  if (bRadio)
-    return PVR_ERROR_NO_ERROR;
-
-  // for tv, use the groups returned by nextpvr
-  std::string response;
-  if (DoRequest("/service?method=channel.groups", response) == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      TiXmlElement* groupsNode = doc.RootElement()->FirstChildElement("groups");
-      TiXmlElement* pGroupNode;
-      for( pGroupNode = groupsNode->FirstChildElement("group"); pGroupNode; pGroupNode=pGroupNode->NextSiblingElement())
-      {
-        memset(&tag, 0, sizeof(PVR_CHANNEL_GROUP));
-        tag.bIsRadio  = false;
-        tag.iPosition = 0; // groups default order, unused
-        std::string group;
-        if ( XMLUtils::GetString(pGroupNode,"name",group) )
-        {
-          // tell XBMC about channel, ignoring "All Channels" since xbmc has an built in group with effectively the same function
-          strcpy(tag.strGroupName,group.c_str());
-          if (strcmp(tag.strGroupName, "All Channels") != 0 && tag.strGroupName[0]!=0)
-          {
-            PVR->TransferChannelGroup(handle, &tag);
-          }
-        }
-      }
-    }
-    else
-    {
-      XBMC->Log(LOG_DEBUG, "GetChannelGroupsAmount");
-    }
-
-  }
-  return PVR_ERROR_NO_ERROR;
-}
-
-PVR_ERROR cPVRClientNextPVR::GetChannelStreamProperties(const PVR_CHANNEL &channel, PVR_NAMED_VALUE *properties, unsigned int *iPropertiesCount)
+PVR_ERROR cPVRClientNextPVR::GetChannelStreamProperties(const PVR_CHANNEL& channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
 {
   LOG_API_CALL(__FUNCTION__);
   XBMC->Log(LOG_DEBUG, "%s:%d:", __FUNCTION__, __LINE__);
-  bool liveStream = IsChannelAPlugin(channel.iUniqueId);
-  if (liveStream || (  m_settings.m_liveStreamingMethod == Transcoded && !channel.bIsRadio) )
+  bool liveStream = m_channels.IsChannelAPlugin(channel.iUniqueId);
+  if (liveStream || (m_settings.m_liveStreamingMethod == Transcoded && !channel.bIsRadio))
   {
-    strncpy(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL,sizeof(properties[0].strName) - 1);
+    strncpy(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL, sizeof(properties[0].strName) - 1);
     if (liveStream)
     {
-      strncpy(properties[0].strValue,m_liveStreams[channel.iUniqueId].c_str(), sizeof(properties[0].strValue) - 1);
+      strncpy(properties[0].strValue, m_channels.m_liveStreams[channel.iUniqueId].c_str(), sizeof(properties[0].strValue) - 1);
       strcpy(properties[1].strName, PVR_STREAM_PROPERTY_ISREALTIMESTREAM);
-      strcpy(properties[1].strValue,"true");
+      strcpy(properties[1].strValue, "true");
       *iPropertiesCount = 2;
     }
     else
     {
-      char line[256];
       if (m_livePlayer != nullptr)
       {
         m_livePlayer->Close();
         m_nowPlaying = NotPlaying;
         m_livePlayer = nullptr;
       }
-      sprintf(line, "http://%s:%d/services/service?method=channel.transcode.m3u8&sid=%s", m_settings.m_hostname.c_str(), m_settings.m_port,m_sid);
+      const std::string line = StringUtils::Format("http://%s:%d/services/service?method=channel.transcode.m3u8&sid=%s", m_settings.m_hostname.c_str(), m_settings.m_port, m_sid);
       m_livePlayer = m_timeshiftBuffer;
       m_livePlayer->Channel(channel.iUniqueId);
       if (m_livePlayer->Open(line))
@@ -1023,11 +542,11 @@ PVR_ERROR cPVRClientNextPVR::GetChannelStreamProperties(const PVR_CHANNEL &chann
         XBMC->Log(LOG_ERROR, "Transcoding Error");
         return PVR_ERROR_FAILED;
       }
-      strncpy(properties[0].strValue,line, sizeof(properties[0].strValue) - 1);
+      strncpy(properties[0].strValue, line.c_str(), sizeof(properties[0].strValue) - 1);
       strcpy(properties[1].strName, PVR_STREAM_PROPERTY_ISREALTIMESTREAM);
-      strcpy(properties[1].strValue,"true");
-      strcpy(properties[2].strName, PVR_STREAM_PROPERTY_MIMETYPE );
-      strcpy(properties[2].strValue,"application/x-mpegURL");
+      strcpy(properties[1].strValue, "true");
+      strcpy(properties[2].strName, PVR_STREAM_PROPERTY_MIMETYPE);
+      strcpy(properties[2].strValue, "application/x-mpegURL");
       *iPropertiesCount = 3;
     }
     return PVR_ERROR_NO_ERROR;
@@ -1035,1309 +554,11 @@ PVR_ERROR cPVRClientNextPVR::GetChannelStreamProperties(const PVR_CHANNEL &chann
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
-
-bool cPVRClientNextPVR::IsChannelAPlugin(int uid)
-{
-  if (m_liveStreams.count(uid)!= 0)
-    if (StringUtils::StartsWith(m_liveStreams[uid],"plugin:") || StringUtils::EndsWithNoCase(m_liveStreams[uid],".m3u8"))
-      return true;
-
-  return false;
-}
-
-
-PVR_ERROR cPVRClientNextPVR::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
-{
-  std::string encodedGroupName = UriEncode(group.strGroupName);
-  LOG_API_CALL(__FUNCTION__);
-
-  char request[512];
-  sprintf(request, "/service?method=channel.list&group_id=%s", encodedGroupName.c_str());
-
-  std::string response;
-  if (DoRequest(request, response) == HTTP_OK)
-  {
-    PVR_CHANNEL_GROUP_MEMBER tag;
-
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      TiXmlElement* channelsNode = doc.RootElement()->FirstChildElement("channels");
-      TiXmlElement* pChannelNode;
-      for( pChannelNode = channelsNode->FirstChildElement("channel"); pChannelNode; pChannelNode=pChannelNode->NextSiblingElement())
-      {
-        memset(&tag, 0, sizeof(PVR_CHANNEL_GROUP_MEMBER));
-        strncpy(tag.strGroupName, group.strGroupName, sizeof(tag.strGroupName));
-        tag.iChannelUniqueId = atoi(pChannelNode->FirstChildElement("id")->FirstChild()->Value());
-        tag.iChannelNumber = atoi(pChannelNode->FirstChildElement("number")->FirstChild()->Value());
-
-        PVR->TransferChannelGroupMember(handle, &tag);
-      }
-    }
-  }
-
-  return PVR_ERROR_NO_ERROR;
-}
-
-/************************************************************/
-/** Record handling **/
-
-int cPVRClientNextPVR::GetNumRecordings(void)
-{
-  // need something more optimal, but this will do for now...
-  // Return -1 on error.
-
-  LOG_API_CALL(__FUNCTION__);
-  if (m_iRecordingCount != 0)
-    return m_iRecordingCount;
-
-  std::string response;
-  if (DoRequest("/service?method=recording.list&filter=ready", response) == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
-      if (recordingsNode != NULL)
-      {
-        TiXmlElement* pRecordingNode;
-        m_iRecordingCount = 0;
-        for( pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode=pRecordingNode->NextSiblingElement())
-        {
-          m_iRecordingCount++;
-        }
-      }
-    }
-  }
-  LOG_API_IRET(__FUNCTION__, m_iRecordingCount);
-  return m_iRecordingCount;
-}
-
-PVR_ERROR cPVRClientNextPVR::GetRecordings(ADDON_HANDLE handle)
-{
-  // include already-completed recordings
-  PVR_ERROR returnValue = PVR_ERROR_NO_ERROR;
-  m_hostFilenames.clear();
-  LOG_API_CALL(__FUNCTION__);
-  int recordingCount = 0;
-  std::string response;
-  if (DoRequest("/service?method=recording.list&filter=all", response) == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      //dump_to_log(&doc, 0);
-      PVR_RECORDING   tag;
-      TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
-      TiXmlElement* pRecordingNode;
-      std::map<std::string, int> names;
-      if (m_settings.m_flattenRecording)
-      {
-        for (pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode = pRecordingNode->NextSiblingElement())
-        {
-          string title;
-          XMLUtils::GetString(pRecordingNode, "name", title);
-          names[title]++;
-        }
-      }
-      for( pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode=pRecordingNode->NextSiblingElement())
-      {
-        tag = {};
-        string title;
-        XMLUtils::GetString(pRecordingNode, "name", title);
-        if (UpdatePvrRecording(pRecordingNode, &tag, title, names[title] == 1))
-        {
-          recordingCount++;
-          PVR->TransferRecordingEntry(handle, &tag);
-        }
-      }
-    }
-    m_iRecordingCount = recordingCount;
-    XBMC->Log(LOG_DEBUG, "Updated recordings %lld", m_lastRecordingUpdateTime);
-  }
-  else
-  {
-    returnValue = PVR_ERROR_SERVER_ERROR;
-  }
-  m_lastRecordingUpdateTime = time(0);
-  LOG_API_IRET(__FUNCTION__, returnValue);
-  return returnValue;
-}
-
-bool cPVRClientNextPVR::UpdatePvrRecording(TiXmlElement* pRecordingNode, PVR_RECORDING *tag, const std::string& title, bool flatten)
-{
-  tag->recordingTime = atol(pRecordingNode->FirstChildElement("start_time_ticks")->FirstChild()->Value());
-
-  std::string status = pRecordingNode->FirstChildElement("status")->FirstChild()->Value();
-  if (status=="Pending"  && tag->recordingTime > time(nullptr) + m_settings.m_serverTimeOffset)
-  {
-    // skip timers
-    return false;
-  }
-  tag->iDuration = atoi(pRecordingNode->FirstChildElement("duration_seconds")->FirstChild()->Value());
-
-  if (status == "Ready" || status == "Pending" || status == "Recording")
-  {
-    if (!flatten)
-    {
-      snprintf(tag->strDirectory, sizeof(tag->strDirectory), "/%s", title.c_str());
-    }
-    if (pRecordingNode->FirstChildElement("desc") != NULL && pRecordingNode->FirstChildElement("desc")->FirstChild() != NULL)
-    {
-      PVR_STRCPY(tag->strPlot, pRecordingNode->FirstChildElement("desc")->FirstChild()->Value());
-    }
-  }
-  else if (status == "Failed")
-  {
-    snprintf(tag->strDirectory,sizeof(tag->strDirectory),"/%s/%s",XBMC->GetLocalizedString(30166), title.c_str());
-    if (pRecordingNode->FirstChildElement("reason") != NULL && pRecordingNode->FirstChildElement("reason")->FirstChild() != NULL)
-    {
-      PVR_STRCPY(tag->strPlot, pRecordingNode->FirstChildElement("reason")->FirstChild()->Value());
-    }
-    if (tag->iDuration < 0)
-    {
-      tag->iDuration = 0;
-    }
-  }
-  else if (status == "Conflict")
-  {
-    // shouldn't happen;
-    return false;
-  }
-  else
-  {
-     XBMC->Log(LOG_ERROR, "Unknown status %s",status.c_str());
-     return false;
-  }
-
-  if (status == "Recording" || status == "Pending"  )
-  {
-    if (pRecordingNode->FirstChildElement("epg_event_oid"))
-    {
-      // EPG Event ID is likely not valid on most older recordings so current or pending only
-      // Linked tags need to be on end time because recordingTime can change because of pre-padding
-
-      tag->iEpgEventId = tag->recordingTime + tag->iDuration;
-    }
-  }
-
-  PVR_STRCPY(tag->strRecordingId, pRecordingNode->FirstChildElement("id")->FirstChild()->Value());
-  PVR_STRCPY(tag->strTitle, title.c_str());
-
-  tag->iSeriesNumber = PVR_RECORDING_INVALID_SERIES_EPISODE;
-  tag->iEpisodeNumber = PVR_RECORDING_INVALID_SERIES_EPISODE;
-
-  if (pRecordingNode->FirstChildElement("subtitle") != NULL && pRecordingNode->FirstChildElement("subtitle")->FirstChild() != NULL)
-  {
-    if (m_settings.m_kodiLook || flatten)
-    {
-      ParseNextPVRSubtitle(pRecordingNode->FirstChildElement("subtitle")->FirstChild()->Value(), tag);
-    }
-    else
-    {
-      PVR_STRCPY(tag->strTitle, pRecordingNode->FirstChildElement("subtitle")->FirstChild()->Value());
-    }
-  }
-
-  if (pRecordingNode->FirstChildElement("playback_position") != NULL && pRecordingNode->FirstChildElement("playback_position")->FirstChild() != NULL)
-  {
-    tag->iLastPlayedPosition = atoi(pRecordingNode->FirstChildElement("playback_position")->FirstChild()->Value());
-  }
-
-  if (pRecordingNode->FirstChildElement("channel_id") != NULL && pRecordingNode->FirstChildElement("channel_id")->FirstChild() != NULL)
-  {
-    tag->iChannelUid = atoi(pRecordingNode->FirstChildElement("channel_id")->FirstChild()->Value());
-    if (tag->iChannelUid == 0)
-    {
-      tag->iChannelUid = PVR_CHANNEL_INVALID_UID;
-    }
-    else
-    {
-      strcpy(tag->strIconPath,GetChannelIconFileName(tag->iChannelUid).c_str());
-    }
-  }
-  else
-  {
-    tag->iChannelUid = PVR_CHANNEL_INVALID_UID;
-  }
-
-  if (pRecordingNode->FirstChildElement("channel") != NULL && pRecordingNode->FirstChildElement("channel")->FirstChild() != NULL)
-  {
-    PVR_STRCPY(tag->strChannelName,pRecordingNode->FirstChildElement("channel")->FirstChild()->Value());
-  }
-
-  std::string recordingFile;
-  if (XMLUtils::GetString(pRecordingNode, "file", recordingFile))
-  {
-    if (m_settings.m_showRecordingSize)
-    {
-      StringUtils::Replace(recordingFile, '\\', '/');
-      if (StringUtils::StartsWith(recordingFile, "//"))
-      {
-        recordingFile = "smb:" + recordingFile;
-      }
-      if (XBMC->FileExists(recordingFile.c_str(), READ_NO_CACHE))
-      {
-        void* fileHandle = XBMC->OpenFile(recordingFile.c_str(), READ_NO_CACHE);
-        tag->sizeInBytes = XBMC->GetFileLength(fileHandle);
-        XBMC->CloseFile(fileHandle);
-      }
-      else
-      {
-        // don't play recording as file
-        recordingFile.clear();
-      }
-    }
-  }
-
-  m_hostFilenames[tag->strRecordingId] = recordingFile;
-
-  // if we use unknown Kodi logs warning and turns it to TV so save some steps
-  tag->channelType = GetChannelType(tag->iChannelUid);
-  if (tag->channelType != PVR_RECORDING_CHANNEL_TYPE_RADIO)
-  {
-    char artworkPath[512];
-    if (m_settings.m_backendVersion < 50000)
-    {
-      snprintf(artworkPath, sizeof(artworkPath), "http://%s:%d/service?method=recording.artwork&sid=%s&recording_id=%s", m_settings.m_hostname.c_str(), m_settings.m_port, m_sid, tag->strRecordingId);
-      PVR_STRCPY(tag->strThumbnailPath, artworkPath);
-      snprintf(artworkPath, sizeof(artworkPath), "http://%s:%d/service?method=recording.fanart&sid=%s&recording_id=%s", m_settings.m_hostname.c_str(), m_settings.m_port, m_sid, tag->strRecordingId);
-      PVR_STRCPY(tag->strFanartPath, artworkPath);
-    }
-    else
-    {
-      if (m_settings.m_sendSidWithMetadata)
-        snprintf(artworkPath, sizeof(artworkPath), "http://%s:%d/service?method=channel.show.artwork&sid=%s&name=%s", m_settings.m_hostname.c_str(), m_settings.m_port, m_sid, UriEncode(title).c_str());
-      else
-        snprintf(artworkPath, sizeof(artworkPath), "http://%s:%d/service?method=channel.show.artwork&name=%s", m_settings.m_hostname.c_str(), m_settings.m_port, UriEncode(title).c_str());
-      PVR_STRCPY(tag->strFanartPath, artworkPath);
-      strcat(artworkPath, "&prefer=poster");
-      PVR_STRCPY(tag->strThumbnailPath, artworkPath);
-    }
-  }
-  if (pRecordingNode->FirstChildElement("genres") != NULL)
-  {
-    std::string genres;
-    TiXmlElement* pGenresNode = pRecordingNode->FirstChildElement("genres");
-    GetAdditiveString(pGenresNode,"genre", EPG_STRING_TOKEN_SEPARATOR, genres, true);
-    tag->iGenreType = EPG_GENRE_USE_STRING;
-    tag->iGenreSubType = 0;
-    PVR_STRCPY(tag->strGenreDescription,genres.c_str());
-  }
-
-  std::string significance;
-  XMLUtils::GetString(pRecordingNode,"significance",significance);
-  if (significance.find("Premiere") != string::npos)
-  {
-    tag->iFlags = PVR_RECORDING_FLAG_IS_PREMIERE;
-  }
-  else if (significance.find("Finale") != string::npos)
-  {
-    tag->iFlags = PVR_RECORDING_FLAG_IS_FINALE;
-  }
-
-  bool played = false;
-  if (XMLUtils::GetBoolean(pRecordingNode, "played", played))
-  {
-    tag->iPlayCount = 1;
-  }
-
-  return true;
-}
-
-bool cPVRClientNextPVR::GetAdditiveString(const TiXmlNode* pRootNode, const char* strTag,
-      const std::string& strSeparator, std::string& strStringValue,
-      bool clear)
-{
-  std::string strTemp;
-  const TiXmlElement* node = pRootNode->FirstChildElement(strTag);
-  bool bResult=false;
-  if (node && node->FirstChild() && clear)
-    strStringValue.clear();
-  while (node)
-  {
-    if (node->FirstChild())
-    {
-      bResult = true;
-      strTemp = node->FirstChild()->Value();
-      const char* clear=node->Attribute("clear");
-      if (strStringValue.empty() || (clear && StringUtils::CompareNoCase(clear,"true")==0))
-        strStringValue = strTemp;
-      else
-        strStringValue += strSeparator+strTemp;
-    }
-    node = node->NextSiblingElement(strTag);
-  }
-
-  return bResult;
-}
-
-void cPVRClientNextPVR::ParseNextPVRSubtitle( const char *episodeName, PVR_RECORDING   *tag)
-{
-    string strEpisodeName =  episodeName;
-    std::regex base_regex("S(\\d\\d)E(\\d+) - ?(.+)?");
-    std::smatch base_match;
-    // note NextPVR does not support S0 for specials
-    if (std::regex_match(strEpisodeName , base_match, base_regex))
-    {
-      if (base_match.size() == 3 || base_match.size() == 4)
-      {
-        std::ssub_match base_sub_match = base_match[1];
-        tag->iSeriesNumber  = std::stoi(base_sub_match.str());
-        base_sub_match = base_match[2];
-        tag->iEpisodeNumber = std::stoi(base_sub_match.str());
-        if (base_match.size() == 4)
-        {
-          base_sub_match = base_match[3];
-          strcpy(tag->strEpisodeName,base_sub_match.str().c_str());
-        }
-      }
-    }
-    else
-    {
-      PVR_STRCPY(tag->strEpisodeName , strEpisodeName.c_str());
-    }
-}
-
-PVR_ERROR cPVRClientNextPVR::DeleteRecording(const PVR_RECORDING &recording)
-{
-  LOG_API_CALL(__FUNCTION__);
-  XBMC->Log(LOG_DEBUG, "DeleteRecording");
-  char request[512];
-  if (recording.recordingTime < time(nullptr) && recording.recordingTime + recording.iDuration > time(nullptr))
-    return PVR_ERROR_RECORDING_RUNNING;
-
-  sprintf(request, "/service?method=recording.delete&recording_id=%s", recording.strRecordingId);
-
-  std::string response;
-  if (DoRequest(request, response) == HTTP_OK)
-  {
-    if (strstr(response.c_str(), "<rsp stat=\"ok\">"))
-    {
-      return PVR_ERROR_NO_ERROR;
-    }
-  }
-  else
-  {
-    XBMC->Log(LOG_DEBUG, "DeleteRecording failed");
-  }
-  return PVR_ERROR_FAILED;
-}
-
-bool cPVRClientNextPVR::ForgetRecording(const PVR_RECORDING& recording)
-{
-  LOG_API_CALL(__FUNCTION__);
-  // tell backend to forget recording history so it can re recorded.
-  std::string request = "/service?method=recording.forget&recording_id=";
-  request.append(recording.strRecordingId);
-  std::string response;
-  return DoRequest(request.c_str(), response) == HTTP_OK;
-}
-
-PVR_ERROR cPVRClientNextPVR::SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition)
-{
-  LOG_API_CALL(__FUNCTION__);
-  XBMC->Log(LOG_DEBUG, "SetRecordingLastPlayedPosition");
-  char request[512];
-  sprintf(request, "/service?method=recording.watched.set&recording_id=%s&position=%d", recording.strRecordingId, lastplayedposition);
-
-  std::string response;
-  if (DoRequest(request, response) == HTTP_OK)
-  {
-    if (strstr(response.c_str(), "<rsp stat=\"ok\">") == NULL)
-    {
-      XBMC->Log(LOG_DEBUG, "SetRecordingLastPlayedPosition failed");
-      return PVR_ERROR_FAILED;
-    }
-    m_lastRecordingUpdateTime = 0;
-  }
-  return PVR_ERROR_NO_ERROR;
-}
-
-int cPVRClientNextPVR::GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
-{
-  LOG_API_CALL(__FUNCTION__);
-  return recording.iLastPlayedPosition;
-}
-
-PVR_ERROR cPVRClientNextPVR::GetRecordingEdl(const PVR_RECORDING& recording, PVR_EDL_ENTRY entries[], int *size)
-{
-  LOG_API_CALL(__FUNCTION__);
-  XBMC->Log(LOG_DEBUG, "GetRecordingEdl");
-  char request[512];
-  sprintf(request, "/service?method=recording.edl&recording_id=%s", recording.strRecordingId);
-
-  std::string response;
-  if (DoRequest(request, response) == HTTP_OK)
-  {
-    if (strstr(response.c_str(), "<rsp stat=\"ok\">") != NULL)
-    {
-      TiXmlDocument doc;
-      if (doc.Parse(response.c_str()) != NULL)
-      {
-        int index = 0;
-        TiXmlElement* commercialsNode = doc.RootElement()->FirstChildElement("commercials");
-        TiXmlElement* pCommercialNode;
-        for( pCommercialNode = commercialsNode->FirstChildElement("commercial"); pCommercialNode; pCommercialNode=pCommercialNode->NextSiblingElement())
-        {
-          PVR_EDL_ENTRY entry;
-          entry.start = atoi(pCommercialNode->FirstChildElement("start")->FirstChild()->Value()) * 1000;
-          entry.end = atoi(pCommercialNode->FirstChildElement("end")->FirstChild()->Value()) * 1000 ;
-          entry.type = PVR_EDL_TYPE_COMBREAK;
-          entries[index] = entry;
-          index++;
-        }
-        *size = index;
-        return PVR_ERROR_NO_ERROR;
-      }
-    }
-  }
-  return PVR_ERROR_FAILED;
-}
-
-/************************************************************/
-/** Timer handling */
-
-
-int cPVRClientNextPVR::GetNumTimers(void)
-{
-  LOG_API_CALL(__FUNCTION__);
-  // Return -1 in case of error.
-  if (m_iTimerCount != -1)
-    return m_iTimerCount;
-
-  std::string response;
-  int timerCount = -1;
-  // get list of recurring recordings
-  if (DoRequest("/service?method=recording.recurring.list", response) == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recurrings");
-      if (recordingsNode != NULL)
-      {
-        TiXmlElement* pRecordingNode;
-        for( pRecordingNode = recordingsNode->FirstChildElement("recurring"); pRecordingNode; pRecordingNode=pRecordingNode->NextSiblingElement())
-        {
-          timerCount++;
-        }
-      }
-    }
-  }
-
-
-  // get list of pending recordings
-  response = "";
-  if (DoRequest("/service?method=recording.list&filter=pending", response) == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
-      if (recordingsNode != NULL)
-      {
-        TiXmlElement* pRecordingNode;
-        for( pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode=pRecordingNode->NextSiblingElement())
-        {
-          timerCount++;
-        }
-      }
-    }
-  }
-  if (timerCount > -1)
-  {
-    m_iTimerCount = timerCount + 1;
-  }
-  LOG_API_IRET(__FUNCTION__, timerCount);
-  return m_iTimerCount;
-}
-
-PVR_ERROR cPVRClientNextPVR::GetTimers(ADDON_HANDLE handle)
-{
-  std::string response;
-  PVR_ERROR returnValue = PVR_ERROR_NO_ERROR;
-  LOG_API_CALL(__FUNCTION__);
-  int timerCount = 0;
-  // first add the recurring recordings
-  if (DoRequest("/service?method=recording.recurring.list", response) == HTTP_OK)
-  {
-    TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
-    {
-      PVR_TIMER tag;
-      TiXmlElement* recurringsNode = doc.RootElement()->FirstChildElement("recurrings");
-      TiXmlElement* pRecurringNode;
-      for( pRecurringNode = recurringsNode->FirstChildElement("recurring"); pRecurringNode; pRecurringNode=pRecurringNode->NextSiblingElement())
-      {
-        memset(&tag, 0, sizeof(tag));
-
-        TiXmlElement* pMatchRulesNode = pRecurringNode->FirstChildElement("matchrules");// ->FirstChildElement("Rules");
-        TiXmlElement* pRulesNode = pMatchRulesNode->FirstChildElement("Rules");// ->FirstChildElement("Rules");
-
-        tag.iClientIndex = atoi(pRecurringNode->FirstChildElement("id")->FirstChild()->Value());
-        tag.iClientChannelUid = atoi(pRulesNode->FirstChildElement("ChannelOID")->FirstChild()->Value());
-
-        tag.iTimerType = pRulesNode->FirstChildElement("EPGTitle") ? TIMER_REPEATING_EPG : TIMER_REPEATING_MANUAL;
-
-        // start/end time
-        if (pRulesNode->FirstChildElement("StartTimeTicks") != NULL)
-        {
-          tag.startTime = atol(pRulesNode->FirstChildElement("StartTimeTicks")->FirstChild()->Value());
-          if (tag.startTime < time(nullptr))
-          {
-            tag.startTime = 0;
-          }
-          else
-          {
-            tag.endTime = atol(pRulesNode->FirstChildElement("EndTimeTicks")->FirstChild()->Value());
-          }
-        }
-
-        // keyword recordings
-        if (pRulesNode->FirstChildElement("AdvancedRules") != NULL)
-        {
-          std::string advancedRulesText = pRulesNode->FirstChildElement("AdvancedRules")->FirstChild()->Value();
-          if (advancedRulesText.find("KEYWORD: ") != string::npos)
-          {
-            tag.iTimerType = TIMER_REPEATING_KEYWORD;
-            tag.startTime = 0;
-            tag.endTime = 0;
-            tag.bStartAnyTime = true;
-            tag.bEndAnyTime = true;
-            strncpy(tag.strEpgSearchString, &advancedRulesText.c_str()[9], sizeof(tag.strEpgSearchString) - 1);
-          }
-          else
-          {
-            tag.iTimerType = TIMER_REPEATING_ADVANCED;
-            tag.startTime = 0;
-            tag.endTime = 0;
-            tag.bStartAnyTime = true;
-            tag.bEndAnyTime = true;
-            tag.bFullTextEpgSearch = true;
-            strncpy(tag.strEpgSearchString, advancedRulesText.c_str(), sizeof(tag.strEpgSearchString) - 1);
-          }
-
-        }
-
-        // days
-        tag.iWeekdays = PVR_WEEKDAY_ALLDAYS;
-        if (pRulesNode->FirstChildElement("Days") != NULL)
-        {
-          std::string daysText = pRulesNode->FirstChildElement("Days")->FirstChild()->Value();
-          tag.iWeekdays = PVR_WEEKDAY_NONE;
-          if (daysText.find("SUN") != string::npos)
-            tag.iWeekdays |= PVR_WEEKDAY_SUNDAY;
-          if (daysText.find("MON") != string::npos)
-            tag.iWeekdays |= PVR_WEEKDAY_MONDAY;
-          if (daysText.find("TUE") != string::npos)
-            tag.iWeekdays |= PVR_WEEKDAY_TUESDAY;
-          if (daysText.find("WED") != string::npos)
-            tag.iWeekdays |= PVR_WEEKDAY_WEDNESDAY;
-          if (daysText.find("THU") != string::npos)
-            tag.iWeekdays |= PVR_WEEKDAY_THURSDAY;
-          if (daysText.find("FRI") != string::npos)
-            tag.iWeekdays |= PVR_WEEKDAY_FRIDAY;
-          if (daysText.find("SAT") != string::npos)
-            tag.iWeekdays |= PVR_WEEKDAY_SATURDAY;
-        }
-
-        // pre/post padding
-        if (pRulesNode->FirstChildElement("PrePadding") != NULL)
-        {
-          tag.iMarginStart = atoi(pRulesNode->FirstChildElement("PrePadding")->FirstChild()->Value());
-          tag.iMarginEnd = atoi(pRulesNode->FirstChildElement("PostPadding")->FirstChild()->Value());
-        }
-
-        // number of recordings to keep
-        if (pRulesNode->FirstChildElement("Keep") != NULL)
-        {
-          tag.iMaxRecordings = atoi(pRulesNode->FirstChildElement("Keep")->FirstChild()->Value());
-        }
-
-        // prevent duplicates
-        if (pRulesNode->FirstChildElement("OnlyNewEpisodes") != NULL)
-        {
-          if (strcmp(pRulesNode->FirstChildElement("OnlyNewEpisodes")->FirstChild()->Value(), "true") == 0)
-          {
-            tag.iPreventDuplicateEpisodes = 1;
-          }
-        }
-
-        // recordings directory ID
-        if (pRulesNode->FirstChildElement("RecordingDirectoryID") != NULL)
-        {
-          tag.iRecordingGroup = 0;
-          if (pRulesNode->FirstChildElement("RecordingDirectoryID")->FirstChild() != NULL)
-          {
-            std::string recordingDirectoryID = pRulesNode->FirstChildElement("RecordingDirectoryID")->FirstChild()->Value();
-            int i = 0;
-            for (auto it = m_settings.m_recordingDirectories.begin(); it != m_settings.m_recordingDirectories.end(); ++it, i++)
-            {
-              std::string bracketed = "[" + m_settings.m_recordingDirectories[i] + "]";
-              if (bracketed == recordingDirectoryID)
-              {
-                tag.iRecordingGroup = i;
-                break;
-              }
-            }
-          }
-        }
-
-        PVR_STRCPY(tag.strTitle,pRecurringNode->FirstChildElement("name")->FirstChild()->Value());
-
-        tag.state = PVR_TIMER_STATE_SCHEDULED;
-
-        PVR_STRCPY(tag.strSummary, "summary");
-
-        // pass timer to xbmc
-        timerCount++;
-        PVR->TransferTimerEntry(handle, &tag);
-      }
-    }
-    // next add the one-off recordings.
-    response = "";
-    if (DoRequest("/service?method=recording.list&filter=pending", response) == HTTP_OK)
-    {
-      TiXmlDocument doc;
-      if (doc.Parse(response.c_str()) != NULL)
-      {
-        PVR_TIMER tag;
-
-        TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
-        TiXmlElement* pRecordingNode;
-        for( pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode=pRecordingNode->NextSiblingElement())
-        {
-          memset(&tag, 0, sizeof(tag));
-          UpdatePvrTimer(pRecordingNode, &tag);
-          // pass timer to xbmc
-          timerCount++;
-          PVR->TransferTimerEntry(handle, &tag);
-        }
-      }
-      response = "";
-      if (DoRequest("/service?method=recording.list&filter=conflict", response) == HTTP_OK)
-      {
-        TiXmlDocument doc;
-        if (doc.Parse(response.c_str()) != NULL)
-        {
-          PVR_TIMER tag;
-
-          TiXmlElement* recordingsNode = doc.RootElement()->FirstChildElement("recordings");
-          TiXmlElement* pRecordingNode;
-          for( pRecordingNode = recordingsNode->FirstChildElement("recording"); pRecordingNode; pRecordingNode=pRecordingNode->NextSiblingElement())
-          {
-            memset(&tag, 0, sizeof(tag));
-            UpdatePvrTimer(pRecordingNode, &tag);
-            // pass timer to xbmc
-            timerCount++;
-            PVR->TransferTimerEntry(handle, &tag);
-          }
-          m_iTimerCount = timerCount;
-        }
-      }
-    }
-  }
-  else
-  {
-    returnValue = PVR_ERROR_SERVER_ERROR;
-  }
-
-  LOG_API_IRET(__FUNCTION__, returnValue);
-  return returnValue;
-}
-
-bool cPVRClientNextPVR::UpdatePvrTimer(TiXmlElement* pRecordingNode, PVR_TIMER *tag)
-{
-  tag->iTimerType = pRecordingNode->FirstChildElement("epg_event_oid") ? TIMER_ONCE_EPG : TIMER_ONCE_MANUAL;
-
-  tag->iClientIndex = atoi(pRecordingNode->FirstChildElement("id")->FirstChild()->Value());
-  tag->iClientChannelUid = atoi(pRecordingNode->FirstChildElement("channel_id")->FirstChild()->Value());
-
-  if (pRecordingNode->FirstChildElement("recurring_parent") != NULL)
-  {
-    tag->iParentClientIndex = atoi(pRecordingNode->FirstChildElement("recurring_parent")->FirstChild()->Value());
-    if (tag->iParentClientIndex != PVR_TIMER_NO_PARENT)
-    {
-      if (tag->iTimerType == TIMER_ONCE_EPG)
-      {
-        tag->iTimerType = TIMER_ONCE_EPG_CHILD;
-      }
-      else
-      {
-        tag->iTimerType = TIMER_ONCE_MANUAL_CHILD;
-      }
-    }
-    if (pRecordingNode->FirstChildElement("epg_event_oid") != NULL && pRecordingNode->FirstChildElement("epg_event_oid")->FirstChild() != NULL)
-    {
-      tag->iEpgUid = atoi(pRecordingNode->FirstChildElement("epg_event_oid")->FirstChild()->Value());
-      XBMC->Log(LOG_DEBUG, "Setting timer epg id %d %d", tag->iClientIndex, tag->iEpgUid);
-    }
-  }
-
-  // pre-padding
-  if (pRecordingNode->FirstChildElement("pre_padding") != NULL)
-  {
-    tag->iMarginStart = atoi(pRecordingNode->FirstChildElement("pre_padding")->FirstChild()->Value());
-  }
-
-  // post-padding
-  if (pRecordingNode->FirstChildElement("post_padding") != NULL)
-  {
-    tag->iMarginEnd = atoi(pRecordingNode->FirstChildElement("post_padding")->FirstChild()->Value());
-  }
-
-  // name
-  PVR_STRCPY(tag->strTitle, pRecordingNode->FirstChildElement("name")->FirstChild()->Value());
-
-  // description
-  if (pRecordingNode->FirstChildElement("desc") != NULL && pRecordingNode->FirstChildElement("desc")->FirstChild() != NULL)
-  {
-    PVR_STRCPY(tag->strSummary, pRecordingNode->FirstChildElement("desc")->FirstChild()->Value());
-  }
-
-  // start/end time
-  char start[32];
-  strncpy(start, pRecordingNode->FirstChildElement("start_time_ticks")->FirstChild()->Value(), sizeof start);
-  start[10] = '\0';
-  tag->startTime           = atol(start);
-  tag->endTime             = tag->startTime + atoi(pRecordingNode->FirstChildElement("duration_seconds")->FirstChild()->Value());
-
-  tag->state = PVR_TIMER_STATE_SCHEDULED;
-  if (pRecordingNode->FirstChildElement("status") != NULL && pRecordingNode->FirstChildElement("status")->FirstChild() != NULL)
-  {
-    std::string status = pRecordingNode->FirstChildElement("status")->FirstChild()->Value();
-    if (status == "Recording" || (status == "Pending"  && tag->startTime < time(nullptr) + m_settings.m_serverTimeOffset) )
-    {
-      tag->state = PVR_TIMER_STATE_RECORDING;
-    }
-    else if (status == "Conflict")
-    {
-      tag->state = PVR_TIMER_STATE_CONFLICT_NOK;
-    }
-  }
-
-  return true;
-}
-
-namespace
-{
-  struct TimerType : PVR_TIMER_TYPE
-  {
-    TimerType(unsigned int id,
-    unsigned int attributes,
-    const std::string &description,
-    const std::vector< std::pair<int, std::string> > &maxRecordingsValues,
-    int maxRecordingsDefault,
-    const std::vector< std::pair<int, std::string> > &dupEpisodesValues,
-    int dupEpisodesDefault,
-    const std::vector< std::pair<int, std::string> > &recordingGroupsValues,
-    int recordingGroupDefault
-    )
-    {
-      memset(this, 0, sizeof(PVR_TIMER_TYPE));
-
-      iId = id;
-      iAttributes = attributes;
-      iMaxRecordingsSize = maxRecordingsValues.size();
-      iMaxRecordingsDefault = maxRecordingsDefault;
-      iPreventDuplicateEpisodesSize = dupEpisodesValues.size();
-      iPreventDuplicateEpisodesDefault = dupEpisodesDefault;
-      iRecordingGroupSize = recordingGroupsValues.size();
-      iRecordingGroupDefault = recordingGroupDefault;
-      strncpy(strDescription, description.c_str(), sizeof(strDescription)-1);
-
-      int i = 0;
-      for (auto it = maxRecordingsValues.begin(); it != maxRecordingsValues.end(); ++it, ++i)
-      {
-        maxRecordings[i].iValue = it->first;
-        strncpy(maxRecordings[i].strDescription, it->second.c_str(), sizeof(maxRecordings[i].strDescription) - 1);
-      }
-
-      i = 0;
-      for (auto it = dupEpisodesValues.begin(); it != dupEpisodesValues.end(); ++it, ++i)
-      {
-        preventDuplicateEpisodes[i].iValue = it->first;
-        strncpy(preventDuplicateEpisodes[i].strDescription, it->second.c_str(), sizeof(preventDuplicateEpisodes[i].strDescription) - 1);
-      }
-
-      i = 0;
-      for (auto it = recordingGroupsValues.begin(); it != recordingGroupsValues.end(); ++it, ++i)
-      {
-        recordingGroup[i].iValue = it->first;
-        strncpy(recordingGroup[i].strDescription, it->second.c_str(), sizeof(recordingGroup[i].strDescription) - 1);
-      }
-    }
-  };
-
-} // unnamed namespace
-
-PVR_ERROR cPVRClientNextPVR::GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
-{
-  LOG_API_CALL(__FUNCTION__);
-  static const int MSG_ONETIME_MANUAL = 30140;
-  static const int MSG_ONETIME_GUIDE = 30141;
-  static const int MSG_REPEATING_MANUAL = 30142;
-  static const int MSG_REPEATING_GUIDE = 30143;
-  static const int MSG_REPEATING_CHILD = 30144;
-  static const int MSG_REPEATING_KEYWORD = 30145;
-  static const int MSG_REPEATING_ADVANCED = 30171;
-
-  static const int MSG_KEEPALL = 30150;
-  static const int MSG_KEEP1 = 30151;
-  static const int MSG_KEEP2 = 30152;
-  static const int MSG_KEEP3 = 30153;
-  static const int MSG_KEEP4 = 30154;
-  static const int MSG_KEEP5 = 30155;
-  static const int MSG_KEEP6 = 30156;
-  static const int MSG_KEEP7 = 30157;
-  static const int MSG_KEEP10 = 30158;
-
-  static const int MSG_SHOWTYPE_FIRSTRUNONLY = 30160;
-  static const int MSG_SHOWTYPE_ANY = 30161;
-
-  /* PVR_Timer.iMaxRecordings values and presentation. */
-  static std::vector< std::pair<int, std::string> > recordingLimitValues;
-  if (recordingLimitValues.size() == 0)
-  {
-    recordingLimitValues.push_back(std::make_pair(NEXTPVR_LIMIT_ASMANY, XBMC->GetLocalizedString(MSG_KEEPALL)));
-    recordingLimitValues.push_back(std::make_pair(NEXTPVR_LIMIT_1, XBMC->GetLocalizedString(MSG_KEEP1)));
-    recordingLimitValues.push_back(std::make_pair(NEXTPVR_LIMIT_2, XBMC->GetLocalizedString(MSG_KEEP2)));
-    recordingLimitValues.push_back(std::make_pair(NEXTPVR_LIMIT_3, XBMC->GetLocalizedString(MSG_KEEP3)));
-    recordingLimitValues.push_back(std::make_pair(NEXTPVR_LIMIT_4, XBMC->GetLocalizedString(MSG_KEEP4)));
-    recordingLimitValues.push_back(std::make_pair(NEXTPVR_LIMIT_5, XBMC->GetLocalizedString(MSG_KEEP5)));
-    recordingLimitValues.push_back(std::make_pair(NEXTPVR_LIMIT_6, XBMC->GetLocalizedString(MSG_KEEP6)));
-    recordingLimitValues.push_back(std::make_pair(NEXTPVR_LIMIT_7, XBMC->GetLocalizedString(MSG_KEEP7)));
-    recordingLimitValues.push_back(std::make_pair(NEXTPVR_LIMIT_10, XBMC->GetLocalizedString(MSG_KEEP10)));
-  }
-
-  /* PVR_Timer.iPreventDuplicateEpisodes values and presentation.*/
-  static std::vector< std::pair<int, std::string> > showTypeValues;
-  if (showTypeValues.size() == 0)
-  {
-    showTypeValues.push_back(std::make_pair(NEXTPVR_SHOWTYPE_FIRSTRUNONLY, XBMC->GetLocalizedString(MSG_SHOWTYPE_FIRSTRUNONLY)));
-    showTypeValues.push_back(std::make_pair(NEXTPVR_SHOWTYPE_ANY, XBMC->GetLocalizedString(MSG_SHOWTYPE_ANY)));
-  }
-
-  /* PVR_Timer.iRecordingGroup values and presentation */
-  int i = 0;
-  static std::vector< std::pair<int, std::string> > recordingGroupValues;
-  for (auto it = m_settings.m_recordingDirectories.begin(); it != m_settings.m_recordingDirectories.end(); ++it, i++)
-  {
-    recordingGroupValues.push_back(std::make_pair(i, m_settings.m_recordingDirectories[i]));
-  }
-
-  static const unsigned int TIMER_MANUAL_ATTRIBS
-    = PVR_TIMER_TYPE_IS_MANUAL |
-      PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-      PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-      PVR_TIMER_TYPE_SUPPORTS_END_TIME |
-      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
-      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN;
-
-  static const unsigned int TIMER_EPG_ATTRIBS
-    = PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
-      PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
-      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN;
-
-  static const unsigned int TIMER_REPEATING_MANUAL_ATTRIBS
-    = PVR_TIMER_TYPE_IS_REPEATING |
-      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |
-      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
-      PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS |
-      PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS;
-
-  static const unsigned int TIMER_REPEATING_EPG_ATTRIBS
-    = PVR_TIMER_TYPE_IS_REPEATING |
-      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |
-      PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS |
-      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
-      PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES |
-      PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL |
-      PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS;
-
-  static const unsigned int TIMER_CHILD_ATTRIBUTES
-    = PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-      PVR_TIMER_TYPE_SUPPORTS_END_TIME |
-      PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES;
-
-  static const unsigned int TIMER_KEYWORD_ATTRIBS
-    = PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-      PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH |
-      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
-      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN;
-
-  static const unsigned int TIMER_REPEATING_KEYWORD_ATTRIBS
-      = PVR_TIMER_TYPE_IS_REPEATING |
-      PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES |
-      PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL |
-      PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS;
-
-  static const unsigned int TIMER_ADVANCED_ATTRIBS
-    = PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-      PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH  |
-      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
-      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN;
-
-
-
-  /* Timer types definition.*/
-  static std::vector< std::unique_ptr< TimerType > > timerTypes;
-  if (timerTypes.size() == 0)
-  {
-    timerTypes.push_back(
-      /* One-shot manual (time and channel based) */
-      std::unique_ptr<TimerType>(new TimerType(
-      /* Type id. */
-      TIMER_ONCE_MANUAL,
-      /* Attributes. */
-      TIMER_MANUAL_ATTRIBS,
-      /* Description. */
-      XBMC->GetLocalizedString(MSG_ONETIME_MANUAL), // "One time (manual)",
-      /* Values definitions for attributes. */
-      recordingLimitValues, m_defaultLimit,
-      showTypeValues, m_defaultShowType,
-      recordingGroupValues, 0)));
-
-    timerTypes.push_back(
-      /* One-shot epg based */
-      std::unique_ptr<TimerType>(new TimerType(
-      /* Type id. */
-      TIMER_ONCE_EPG,
-      /* Attributes. */
-      TIMER_EPG_ATTRIBS,
-      /* Description. */
-      XBMC->GetLocalizedString(MSG_ONETIME_GUIDE), // "One time (guide)",
-      /* Values definitions for attributes. */
-      recordingLimitValues, m_defaultLimit,
-      showTypeValues, m_defaultShowType,
-      recordingGroupValues, 0)));
-
-    timerTypes.push_back(
-      /* Repeating manual (time and channel based) Parent */
-      std::unique_ptr<TimerType>(new TimerType(
-      /* Type id. */
-      TIMER_REPEATING_MANUAL,
-      /* Attributes. */
-      TIMER_MANUAL_ATTRIBS | TIMER_REPEATING_MANUAL_ATTRIBS,
-      /* Description. */
-      XBMC->GetLocalizedString(MSG_REPEATING_MANUAL), // "Repeating (manual)"
-      /* Values definitions for attributes. */
-      recordingLimitValues, m_defaultLimit,
-      showTypeValues, m_defaultShowType,
-      recordingGroupValues, 0)));
-
-    timerTypes.push_back(
-      /* Repeating epg based Parent*/
-      std::unique_ptr<TimerType>(new TimerType(
-      /* Type id. */
-      TIMER_REPEATING_EPG,
-      /* Attributes. */
-      TIMER_EPG_ATTRIBS | TIMER_REPEATING_EPG_ATTRIBS,
-      /* Description. */
-      XBMC->GetLocalizedString(MSG_REPEATING_GUIDE), // "Repeating (guide)"
-      /* Values definitions for attributes. */
-      recordingLimitValues, m_defaultLimit,
-      showTypeValues, m_defaultShowType,
-      recordingGroupValues, 0)));
-
-    timerTypes.push_back(
-      /* Read-only one-shot for timers generated by timerec */
-      std::unique_ptr<TimerType>(new TimerType(
-      /* Type id. */
-      TIMER_ONCE_MANUAL_CHILD,
-      /* Attributes. */
-      TIMER_MANUAL_ATTRIBS | TIMER_CHILD_ATTRIBUTES,
-      /* Description. */
-      XBMC->GetLocalizedString(MSG_REPEATING_CHILD), // "Created by Repeating Timer"
-      /* Values definitions for attributes. */
-      recordingLimitValues, m_defaultLimit,
-      showTypeValues, m_defaultShowType,
-      recordingGroupValues, 0)));
-
-    timerTypes.push_back(
-      /* Read-only one-shot for timers generated by autorec */
-      std::unique_ptr<TimerType>(new TimerType(
-      /* Type id. */
-      TIMER_ONCE_EPG_CHILD,
-      /* Attributes. */
-      TIMER_EPG_ATTRIBS | TIMER_CHILD_ATTRIBUTES,
-      /* Description. */
-      XBMC->GetLocalizedString(MSG_REPEATING_CHILD), // "Created by Repeating Timer"
-      /* Values definitions for attributes. */
-      recordingLimitValues, m_defaultLimit,
-      showTypeValues, m_defaultShowType,
-      recordingGroupValues, 0)));
-
-    timerTypes.push_back(
-      /* Repeating epg based Parent*/
-      std::unique_ptr<TimerType>(new TimerType(
-      /* Type id. */
-      TIMER_REPEATING_KEYWORD,
-      /* Attributes. */
-      TIMER_KEYWORD_ATTRIBS | TIMER_REPEATING_KEYWORD_ATTRIBS,
-      /* Description. */
-      XBMC->GetLocalizedString(MSG_REPEATING_KEYWORD), // "Repeating (keyword)"
-      /* Values definitions for attributes. */
-      recordingLimitValues, m_defaultLimit,
-      showTypeValues, m_defaultShowType,
-      recordingGroupValues, 0)));
-
-    timerTypes.push_back(
-      /* Repeating epg based Parent*/
-      std::unique_ptr<TimerType>(new TimerType(
-      /* Type id. */
-      TIMER_REPEATING_ADVANCED,
-      /* Attributes. */
-      TIMER_ADVANCED_ATTRIBS | TIMER_REPEATING_KEYWORD_ATTRIBS,
-      /* Description. */
-      XBMC->GetLocalizedString(MSG_REPEATING_ADVANCED), // "Repeating (advanced)"
-      /* Values definitions for attributes. */
-      recordingLimitValues, m_defaultLimit,
-      showTypeValues, m_defaultShowType,
-      recordingGroupValues, 0)));
-  }
-
-  /* Copy data to target array. */
-  i = 0;
-  for (auto it = timerTypes.begin(); it != timerTypes.end(); ++it, ++i)
-    types[i] = **it;
-
-  *size = timerTypes.size();
-
-  return PVR_ERROR_NO_ERROR;
-}
-
-std::string cPVRClientNextPVR::GetDayString(int dayMask)
-{
-  std::string days;
-  if (dayMask == (PVR_WEEKDAY_SATURDAY | PVR_WEEKDAY_SUNDAY))
-  {
-    days = "WEEKENDS";
-  }
-  else if (dayMask == (PVR_WEEKDAY_MONDAY | PVR_WEEKDAY_TUESDAY | PVR_WEEKDAY_WEDNESDAY | PVR_WEEKDAY_THURSDAY | PVR_WEEKDAY_FRIDAY))
-  {
-    days = "WEEKDAYS";
-  }
-  else
-  {
-    if (dayMask & PVR_WEEKDAY_SATURDAY)
-      days += "SAT:";
-    if (dayMask & PVR_WEEKDAY_SUNDAY)
-      days += "SUN:";
-    if (dayMask & PVR_WEEKDAY_MONDAY)
-      days += "MON:";
-    if (dayMask & PVR_WEEKDAY_TUESDAY)
-      days += "TUE:";
-    if (dayMask & PVR_WEEKDAY_WEDNESDAY)
-      days += "WED:";
-    if (dayMask & PVR_WEEKDAY_THURSDAY)
-      days += "THU:";
-    if (dayMask & PVR_WEEKDAY_FRIDAY)
-      days += "FRI:";
-  }
-
-  return days;
-}
-
-PVR_ERROR cPVRClientNextPVR::AddTimer(const PVR_TIMER &timerinfo)
-{
-  // editing recording is not supported
-  //if (timerinfo.iClientIndex != PVR_TIMER_NO_CLIENT_INDEX)
-  //{
-  //  return PVR_ERROR_NOT_IMPLEMENTED;
-  //}
-
-  char request[1024];
-
-  char preventDuplicates[16];
-  LOG_API_CALL(__FUNCTION__);
-  if (timerinfo.iPreventDuplicateEpisodes)
-    strcpy(preventDuplicates, "true");
-  else
-    strcpy(preventDuplicates, "false");
-
-  const std::string encodedName = UriEncode(timerinfo.strTitle);
-  const std::string encodedKeyword = UriEncode(timerinfo.strEpgSearchString);
-  const std::string days = GetDayString(timerinfo.iWeekdays);
-  const std::string directory = UriEncode( m_settings.m_recordingDirectories[timerinfo.iRecordingGroup]);
-  const std::string oidKey = to_string(timerinfo.iEpgUid) + ":" + to_string(timerinfo.iClientChannelUid);
-  const int epgOid = m_epgOidLookup[oidKey];
-  XBMC->Log(LOG_DEBUG, "TIMER_%d %s",epgOid,oidKey.c_str());
-  switch (timerinfo.iTimerType)
-  {
-  case TIMER_ONCE_MANUAL:
-    XBMC->Log(LOG_DEBUG, "TIMER_ONCE_MANUAL");
-    // build one-off recording request
-    snprintf(request, sizeof(request), "/service?method=recording.save&name=%s&channel=%d&time_t=%d&duration=%d&pre_padding=%d&post_padding=%d&directory_id=%s",
-      encodedName.c_str(),
-      timerinfo.iClientChannelUid,
-      (int)timerinfo.startTime,
-      (int)(timerinfo.endTime - timerinfo.startTime),
-      (int)timerinfo.iMarginStart,
-      (int)timerinfo.iMarginEnd,
-      directory.c_str()
-      );
-    break;
-
-  case TIMER_ONCE_EPG:
-    XBMC->Log(LOG_DEBUG, "TIMER_ONCE_EPG");
-    // build one-off recording request
-    snprintf(request, sizeof(request), "/service?method=recording.save&recording_id=%d&event_id=%d&pre_padding=%d&post_padding=%d&directory_id=%s",
-      timerinfo.iClientIndex,
-      epgOid,
-      (int)timerinfo.iMarginStart,
-      (int)timerinfo.iMarginEnd,
-      directory.c_str());
-    break;
-
-  case TIMER_REPEATING_EPG:
-    if (timerinfo.iClientChannelUid == PVR_TIMER_ANY_CHANNEL)
-    {
-      // Fake a manual recording
-      XBMC->Log(LOG_DEBUG, "TIMER_REPEATING_EPG ANY CHANNEL");
-      string title = encodedName + "%";
-      snprintf(request, sizeof(request), "/service?method=recording.recurring.save&name=%s&channel_id=%d&start_time=%d&end_time=%d&keep=%d&pre_padding=%d&post_padding=%d&day_mask=%s&directory_id=%s,&keyword=%s",
-        encodedName.c_str(),
-        timerinfo.iClientChannelUid,
-        (int)timerinfo.startTime,
-        (int)timerinfo.endTime,
-        (int)timerinfo.iMaxRecordings,
-        (int)timerinfo.iMarginStart,
-        (int)timerinfo.iMarginEnd,
-        days.c_str(),
-        directory.c_str(),
-        title.c_str()
-        );
-    }
-    else
-    {
-      XBMC->Log(LOG_DEBUG, "TIMER_REPEATING_EPG");
-      // build recurring recording request
-      snprintf(request, sizeof(request), "/service?method=recording.recurring.save&recurring_id=%d&event_id=%d&keep=%d&pre_padding=%d&post_padding=%d&day_mask=%s&directory_id=%s&only_new=%s",
-        timerinfo.iClientIndex,
-        epgOid,
-        (int)timerinfo.iMaxRecordings,
-        (int)timerinfo.iMarginStart,
-        (int)timerinfo.iMarginEnd,
-        days.c_str(),
-        directory.c_str(),
-        preventDuplicates
-        );
-    }
-    break;
-
-  case TIMER_REPEATING_MANUAL:
-    XBMC->Log(LOG_DEBUG, "TIMER_REPEATING_MANUAL");
-    // build manual recurring request
-    snprintf(request, sizeof(request), "/service?method=recording.recurring.save&recurring_id=%d&name=%s&channel_id=%d&start_time=%d&end_time=%d&keep=%d&pre_padding=%d&post_padding=%d&day_mask=%s&directory_id=%s",
-      timerinfo.iClientIndex,
-      encodedName.c_str(),
-      timerinfo.iClientChannelUid,
-      (int)timerinfo.startTime,
-      (int)timerinfo.endTime,
-      (int)timerinfo.iMaxRecordings,
-      (int)timerinfo.iMarginStart,
-      (int)timerinfo.iMarginEnd,
-      days.c_str(),
-      directory.c_str()
-      );
-    break;
-
-  case TIMER_REPEATING_KEYWORD:
-    XBMC->Log(LOG_DEBUG, "TIMER_REPEATING_KEYWORD");
-    // build manual recurring request
-    snprintf(request, sizeof(request), "/service?method=recording.recurring.save&recurring_id=%d&name=%s&channel_id=%d&start_time=%d&end_time=%d&keep=%d&pre_padding=%d&post_padding=%d&directory_id=%s&keyword=%s&only_new=%s",
-      timerinfo.iClientIndex,
-      encodedName.c_str(),
-      timerinfo.iClientChannelUid,
-      (int)timerinfo.startTime,
-      (int)timerinfo.endTime,
-      (int)timerinfo.iMaxRecordings,
-      (int)timerinfo.iMarginStart,
-      (int)timerinfo.iMarginEnd,
-      directory.c_str(),
-      encodedKeyword.c_str(),
-      preventDuplicates
-      );
-    break;
-
-  case TIMER_REPEATING_ADVANCED:
-    XBMC->Log(LOG_DEBUG, "TIMER_REPEATING_ADVANCED");
-    // build manual advanced recurring request
-    snprintf(request, sizeof(request), "/service?method=recording.recurring.save&recurring_type=advanced&recurring_id=%d&name=%s&channel_id=%d&start_time=%d&end_time=%d&keep=%d&pre_padding=%d&post_padding=%d&directory_id=%s&advanced=%s&only_new=%s",
-      timerinfo.iClientIndex,
-      encodedName.c_str(),
-      timerinfo.iClientChannelUid,
-      (int)timerinfo.startTime,
-      (int)timerinfo.endTime,
-      (int)timerinfo.iMaxRecordings,
-      (int)timerinfo.iMarginStart,
-      (int)timerinfo.iMarginEnd,
-      directory.c_str(),
-      encodedKeyword.c_str(),
-      preventDuplicates
-      );
-    break;
-  }
-
-  // send request to NextPVR
-  std::string response;
-  if (DoRequest(request, response) == HTTP_OK)
-  {
-    if (strstr(response.c_str(), "<rsp stat=\"ok\">"))
-    {
-      if (timerinfo.startTime <= time(nullptr) && timerinfo.endTime > time(nullptr))
-        PVR->TriggerRecordingUpdate();
-      PVR->TriggerTimerUpdate();
-      return PVR_ERROR_NO_ERROR;
-    }
-  }
-
-  return PVR_ERROR_FAILED;
-}
-
-PVR_ERROR cPVRClientNextPVR::DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
-{
-  char request[512];
-  LOG_API_CALL(__FUNCTION__);
-  sprintf(request, "/service?method=recording.delete&recording_id=%d", timer.iClientIndex);
-
-  // handle recurring recordings
-  if (timer.iTimerType >= TIMER_REPEATING_MIN && timer.iTimerType <= TIMER_REPEATING_MAX)
-  {
-    sprintf(request, "/service?method=recording.recurring.delete&recurring_id=%d", timer.iClientIndex);
-  }
-
-  std::string response;
-  if (DoRequest(request, response) == HTTP_OK)
-  {
-    if (strstr(response.c_str(), "<rsp stat=\"ok\">"))
-    {
-      PVR->TriggerTimerUpdate();
-      if (timer.startTime <= time(nullptr) && timer.endTime > time(nullptr))
-        PVR->TriggerRecordingUpdate();
-      return PVR_ERROR_NO_ERROR;
-    }
-  }
-
-  return PVR_ERROR_FAILED;
-}
-
-PVR_ERROR cPVRClientNextPVR::UpdateTimer(const PVR_TIMER &timerinfo)
-{
-  LOG_API_CALL(__FUNCTION__);
-  // not supported
-  return AddTimer(timerinfo);
-}
-
-
 /************************************************************/
 /** Live stream handling */
-bool cPVRClientNextPVR::OpenLiveStream(const PVR_CHANNEL &channelinfo)
+bool cPVRClientNextPVR::OpenLiveStream(const PVR_CHANNEL& channelinfo)
 {
-  char line[256];
+  std::string line;
   LOG_API_CALL(__FUNCTION__);
   if (channelinfo.bIsRadio == false)
   {
@@ -2347,33 +568,33 @@ bool cPVRClientNextPVR::OpenLiveStream(const PVR_CHANNEL &channelinfo)
   {
     m_nowPlaying = Radio;
   }
-  if (m_liveStreams.count(channelinfo.iUniqueId)!= 0)
+  if (m_channels.m_liveStreams.count(channelinfo.iUniqueId) != 0)
   {
-    snprintf(line,sizeof(line),"%s",m_liveStreams[channelinfo.iUniqueId].c_str());
+    line = m_channels.m_liveStreams[channelinfo.iUniqueId];
     m_livePlayer = m_realTimeBuffer;
   }
   else if (channelinfo.bIsRadio == false && m_supportsLiveTimeshift && m_settings.m_liveStreamingMethod == Timeshift)
   {
-    sprintf(line, "GET /live?channeloid=%d&mode=liveshift&client=XBMC-%s HTTP/1.0\r\n", channelinfo.iUniqueId, m_sid);
+    line = StringUtils::Format("GET /live?channeloid=%d&mode=liveshift&client=XBMC-%s HTTP/1.0\r\n", channelinfo.iUniqueId, m_sid);
     m_livePlayer = m_timeshiftBuffer;
   }
-  else if ( m_settings.m_liveStreamingMethod == RollingFile)
+  else if (m_settings.m_liveStreamingMethod == RollingFile)
   {
-    sprintf(line, "http://%s:%d/live?channeloid=%d&client=XBMC-%s&epgmode=true", m_settings.m_hostname.c_str(), m_settings.m_port, channelinfo.iUniqueId, m_sid);
+    line = StringUtils::Format("http://%s:%d/live?channeloid=%d&client=XBMC-%s&epgmode=true", m_settings.m_hostname.c_str(), m_settings.m_port, channelinfo.iUniqueId, m_sid);
     m_livePlayer = m_timeshiftBuffer;
   }
-  else if ( m_settings.m_liveStreamingMethod == ClientTimeshift)
+  else if (m_settings.m_liveStreamingMethod == ClientTimeshift)
   {
-    sprintf(line, "http://%s:%d/live?channeloid=%d&client=%s&sid=%s", m_settings.m_hostname.c_str(), m_settings.m_port, channelinfo.iUniqueId, m_sid,m_sid);
+    line = StringUtils::Format("http://%s:%d/live?channeloid=%d&client=%s&sid=%s", m_settings.m_hostname.c_str(), m_settings.m_port, channelinfo.iUniqueId, m_sid, m_sid);
     m_livePlayer = m_timeshiftBuffer;
     m_livePlayer->Channel(channelinfo.iUniqueId);
   }
   else
   {
-    sprintf(line, "http://%s:%d/live?channeloid=%d&client=XBMC-%s", m_settings.m_hostname.c_str(), m_settings.m_port, channelinfo.iUniqueId, m_sid);
+    line = StringUtils::Format("http://%s:%d/live?channeloid=%d&client=XBMC-%s", m_settings.m_hostname.c_str(), m_settings.m_port, channelinfo.iUniqueId, m_sid);
     m_livePlayer = m_realTimeBuffer;
   }
-  XBMC->Log(LOG_INFO, "Calling Open(%s) on tsb!", line);
+  XBMC->Log(LOG_INFO, "Calling Open(%s) on tsb!", line.c_str());
   if (m_livePlayer->Open(line, channelinfo.bIsRadio))
   {
     return true;
@@ -2381,7 +602,7 @@ bool cPVRClientNextPVR::OpenLiveStream(const PVR_CHANNEL &channelinfo)
   return false;
 }
 
-int cPVRClientNextPVR::ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize)
+int cPVRClientNextPVR::ReadLiveStream(unsigned char* pBuffer, unsigned int iBufferSize)
 {
   LOG_API_CALL(__FUNCTION__);
   return m_livePlayer->Read(pBuffer, iBufferSize);
@@ -2420,7 +641,7 @@ long long cPVRClientNextPVR::LengthLiveStream(void)
   return m_livePlayer->Length();
 }
 
-PVR_ERROR cPVRClientNextPVR::GetSignalStatus(PVR_SIGNAL_STATUS *signalStatus)
+PVR_ERROR cPVRClientNextPVR::GetSignalStatus(PVR_SIGNAL_STATUS* signalStatus)
 {
   LOG_API_CALL(__FUNCTION__);
   // Not supported yet
@@ -2435,7 +656,7 @@ PVR_ERROR cPVRClientNextPVR::GetSignalStatus(PVR_SIGNAL_STATUS *signalStatus)
 bool cPVRClientNextPVR::CanPauseStream(void)
 {
   LOG_API_CALL(__FUNCTION__);
-  if (m_nowPlaying == Recording )
+  if (m_nowPlaying == Recording)
   {
     return true;
   }
@@ -2449,7 +670,7 @@ bool cPVRClientNextPVR::CanPauseStream(void)
 void cPVRClientNextPVR::PauseStream(bool bPaused)
 {
   LOG_API_CALL(__FUNCTION__);
-  if (m_nowPlaying == Recording )
+  if (m_nowPlaying == Recording)
     m_recordingBuffer->PauseStream(bPaused);
   else
     m_livePlayer->PauseStream(bPaused);
@@ -2458,7 +679,7 @@ void cPVRClientNextPVR::PauseStream(bool bPaused)
 bool cPVRClientNextPVR::CanSeekStream(void)
 {
   LOG_API_CALL(__FUNCTION__);
-  if (m_nowPlaying == Recording )
+  if (m_nowPlaying == Recording)
     return true;
   else
     return m_livePlayer->CanSeekStream();
@@ -2468,18 +689,14 @@ bool cPVRClientNextPVR::CanSeekStream(void)
 /** Record stream handling */
 
 
-bool cPVRClientNextPVR::OpenRecordedStream(const PVR_RECORDING &recording)
+bool cPVRClientNextPVR::OpenRecordedStream(const PVR_RECORDING& recording)
 {
   PVR_RECORDING copyRecording = recording;
   LOG_API_CALL(__FUNCTION__);
-  m_currentRecordingLength = 0;
-  m_currentRecordingPosition = 0;
-
-  char line[1024];
   m_nowPlaying = Recording;
-  strcpy(copyRecording.strDirectory,m_hostFilenames[recording.strRecordingId].c_str());
-  snprintf(line, sizeof(line), "http://%s:%d/live?recording=%s&client=XBMC-%s", m_settings.m_hostname.c_str(), m_settings.m_port, recording.strRecordingId, m_sid);
-  return m_recordingBuffer->Open(line,copyRecording);
+  strcpy(copyRecording.strDirectory, m_recordings.m_hostFilenames[recording.strRecordingId].c_str());
+  const std::string line = StringUtils::Format("http://%s:%d/live?recording=%s&client=XBMC-%s", m_settings.m_hostname.c_str(), m_settings.m_port, recording.strRecordingId, m_sid);
+  return m_recordingBuffer->Open(line, copyRecording);
 }
 
 void cPVRClientNextPVR::CloseRecordedStream(void)
@@ -2487,12 +704,10 @@ void cPVRClientNextPVR::CloseRecordedStream(void)
   LOG_API_CALL(__FUNCTION__);
   m_recordingBuffer->Close();
   m_recordingBuffer->SetDuration(0);
-  m_currentRecordingLength = 0;
-  m_currentRecordingPosition = 0;
   m_nowPlaying = NotPlaying;
 }
 
-int cPVRClientNextPVR::ReadRecordedStream(unsigned char *pBuffer, unsigned int iBufferSize)
+int cPVRClientNextPVR::ReadRecordedStream(unsigned char* pBuffer, unsigned int iBufferSize)
 {
   LOG_API_CALL(__FUNCTION__);
   iBufferSize = m_recordingBuffer->Read(pBuffer, iBufferSize);
@@ -2505,24 +720,16 @@ long long cPVRClientNextPVR::SeekRecordedStream(long long iPosition, int iWhence
   return m_recordingBuffer->Seek(iPosition, iWhence);
 }
 
-long long  cPVRClientNextPVR::LengthRecordedStream(void)
+long long cPVRClientNextPVR::LengthRecordedStream(void)
 {
   LOG_API_CALL(__FUNCTION__);
   return m_recordingBuffer->Length();
 }
 
-/************************************************************/
-/** http handling */
-int cPVRClientNextPVR::DoRequest(const char *resource, std::string &response)
-{
-  int resultCode = m_request.DoRequest(resource, response);
-  return resultCode;
-}
-
 bool cPVRClientNextPVR::IsTimeshifting()
 {
   LOG_API_CALL(__FUNCTION__);
-  if (m_nowPlaying == Recording )
+  if (m_nowPlaying == Recording)
     return false;
   else
     return m_livePlayer->IsTimeshifting();
@@ -2532,7 +739,7 @@ bool cPVRClientNextPVR::IsRealTimeStream()
 {
   LOG_API_CALL(__FUNCTION__);
   bool retval;
-  if (m_nowPlaying == Recording )
+  if (m_nowPlaying == Recording)
   {
     retval = m_recordingBuffer->IsRealTimeStream();
   }
@@ -2543,11 +750,11 @@ bool cPVRClientNextPVR::IsRealTimeStream()
   return retval;
 }
 
-PVR_ERROR cPVRClientNextPVR::GetStreamTimes(PVR_STREAM_TIMES *stimes)
+PVR_ERROR cPVRClientNextPVR::GetStreamTimes(PVR_STREAM_TIMES* stimes)
 {
   PVR_ERROR rez;
   LOG_API_CALL(__FUNCTION__);
-  if (m_nowPlaying == Recording )
+  if (m_nowPlaying == Recording)
     rez = m_recordingBuffer->GetStreamTimes(stimes);
   else
     rez = m_livePlayer->GetStreamTimes(stimes);
@@ -2573,135 +780,3 @@ PVR_ERROR cPVRClientNextPVR::GetStreamReadChunkSize(int* chunksize)
   LOG_API_IRET(__FUNCTION__, *chunksize);
   return rez;
 }
-
-#if DEBUGGING_XML
-
-// ----------------------------------------------------------------------
-// LOG dump and indenting utility functions
-// ----------------------------------------------------------------------
-const unsigned int NUM_INDENTS_PER_SPACE=2;
-
-const char * getIndent( unsigned int numIndents )
-{
-  static const char * pINDENT="                                      + ";
-  static const unsigned int LENGTH=strlen( pINDENT );
-  unsigned int n=numIndents*NUM_INDENTS_PER_SPACE;
-  if ( n > LENGTH ) n = LENGTH;
-
-  return &pINDENT[ LENGTH-n ];
-}
-
-// same as getIndent but no "+" at the end
-const char * getIndentAlt( unsigned int numIndents )
-{
-  static const char * pINDENT="                                        ";
-  static const unsigned int LENGTH=strlen( pINDENT );
-  unsigned int n=numIndents*NUM_INDENTS_PER_SPACE;
-  if ( n > LENGTH ) n = LENGTH;
-
-  return &pINDENT[ LENGTH-n ];
-}
-
-int dump_attribs_to_stdout(TiXmlElement* pElement, unsigned int indent)
-{
-  if ( !pElement ) return 0;
-
-  TiXmlAttribute* pAttrib=pElement->FirstAttribute();
-  int i=0;
-  int ival;
-  double dval;
-  const char* pIndent=getIndent(indent);
-  // XBMC->Log(LOG_INFO, "\n");
-  while (pAttrib)
-  {
-    char buf[1024];
-    sprintf(buf, "%s%s: value=[%s]", pIndent, pAttrib->Name(), pAttrib->Value());
-    // XBMC->Log(LOG_INFO,  "%s%s: value=[%s]", pIndent, pAttrib->Name(), pAttrib->Value());
-
-    if (pAttrib->QueryIntValue(&ival)==TIXML_SUCCESS)
-    {
-      sprintf(buf + strlen(buf), " int=%d", ival);
-      // XBMC->Log(LOG_INFO,  " int=%d", ival);
-    }
-    if (pAttrib->QueryDoubleValue(&dval)==TIXML_SUCCESS)
-    {
-      sprintf(buf + strlen(buf), " d=%1.1f", dval);
-      // XBMC->Log(LOG_INFO,  " d=%1.1f", dval);
-    }
-    XBMC->Log(LOG_INFO,  "%s", buf );
-    i++;
-    pAttrib=pAttrib->Next();
-  }
-  return i;
-}
-
-void dump_to_log( TiXmlNode* pParent, unsigned int indent)
-{
-  if ( !pParent ) return;
-
-  char buf[2048];
-  TiXmlNode* pChild;
-  TiXmlText* pText;
-  int t = pParent->Type();
-  sprintf(buf, "%s", getIndent(indent));
-  // XBMC->Log(LOG_INFO,  "%s", getIndent(indent));
-  int num;
-
-  switch ( t )
-  {
-  case TiXmlNode::TINYXML_DOCUMENT:
-    sprintf(buf + strlen(buf), "Document");
-    // XBMC->Log(LOG_INFO,  "Document" );
-    break;
-
-  case TiXmlNode::TINYXML_ELEMENT:
-    sprintf(buf + strlen(buf), "Element [%s]", pParent->Value());
-    // XBMC->Log(LOG_INFO,  "Element [%s]", pParent->Value() );
-    num=dump_attribs_to_stdout(pParent->ToElement(), indent+1);
-    switch(num)
-    {
-      case 0:
-        sprintf(buf + strlen(buf), " (No attributes)");
-        // XBMC->Log(LOG_INFO,  " (No attributes)");
-        break;
-      case 1:
-        sprintf(buf + strlen(buf), "%s1 attribute", getIndentAlt(indent));
-        // XBMC->Log(LOG_INFO,  "%s1 attribute", getIndentAlt(indent));
-        break;
-      default:
-        sprintf(buf + strlen(buf), "%s%d attributes", getIndentAlt(indent), num);
-        // XBMC->Log(LOG_INFO,  "%s%d attributes", getIndentAlt(indent), num);
-        break;
-    }
-    break;
-
-  case TiXmlNode::TINYXML_COMMENT:
-    sprintf(buf + strlen(buf), "Comment: [%s]", pParent->Value());
-    //XBMC->Log(LOG_INFO,  "Comment: [%s]", pParent->Value());
-    break;
-
-  case TiXmlNode::TINYXML_UNKNOWN:
-    sprintf(buf + strlen(buf), "Unknown");
-    // XBMC->Log(LOG_INFO,  "Unknown" );
-    break;
-
-  case TiXmlNode::TINYXML_TEXT:
-    pText = pParent->ToText();
-    sprintf(buf + strlen(buf), "Text: [%s]", pText->Value());
-    // XBMC->Log(LOG_INFO,  "Text: [%s]", pText->Value() );
-    break;
-
-  case TiXmlNode::TINYXML_DECLARATION:
-    sprintf(buf + strlen(buf), "Declaration");
-    // XBMC->Log(LOG_INFO,  "Declaration" );
-    break;
-  default:
-    break;
-  }
-  XBMC->Log(LOG_ERROR,  "%s\n", buf );
-  for ( pChild = pParent->FirstChild(); pChild != 0; pChild = pChild->NextSibling())
-  {
-    dump_to_log( pChild, indent+1 );
-  }
-}
-#endif // DEBUGGING_XML

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -37,23 +37,6 @@ extern "C"
   ADDON_STATUS ADDON_SetSetting(const char* settingName, const void* settingValue);
 }
 
-/* Globals */
-int g_iNextPVRXBMCBuild = 0;
-
-/* PVR client version (don't forget to update also the addon.xml and the Changelog.txt files) */
-#define PVRCLIENT_NEXTPVR_VERSION_STRING "1.0.0.0"
-#define NEXTPVRC_MIN_VERSION_STRING "4.2.4"
-
-#define DEBUGGING_XML 0
-#define DEBUGGING_API 0
-#if DEBUGGING_API
-#define LOG_API_CALL(f) XBMC->Log(LOG_INFO, "%s:  called!", f)
-#define LOG_API_IRET(f, i) XBMC->Log(LOG_INFO, "%s: returns %d", f, i)
-#else
-#define LOG_API_CALL(f)
-#define LOG_API_IRET(f, i)
-#endif
-
 const char SAFE[256] = {
     /*      0 1 2 3  4 5 6 7  8 9 A B  C D E F */
     /* 0 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -265,7 +248,6 @@ void cPVRClientNextPVR::ConfigurePostConnectionOptions()
  */
 bool cPVRClientNextPVR::IsUp()
 {
-  LOG_API_CALL(__FUNCTION__);
   // check time since last time Recordings were updated, update if it has been awhile
   if (m_bConnected == true && m_nowPlaying == NotPlaying && m_lastRecordingUpdateTime != MAXINT64 && time(0) > (m_lastRecordingUpdateTime + 60))
   {
@@ -316,7 +298,6 @@ bool cPVRClientNextPVR::IsUp()
 
 void* cPVRClientNextPVR::Process(void)
 {
-  LOG_API_CALL(__FUNCTION__);
   while (!IsStopped())
   {
     IsUp();
@@ -378,7 +359,6 @@ void cPVRClientNextPVR::SendWakeOnLan()
 // Used among others for the server name string in the "Recordings" view
 const char* cPVRClientNextPVR::GetBackendName(void)
 {
-  LOG_API_CALL(__FUNCTION__);
   if (!m_bConnected)
   {
     return m_settings.m_hostname.c_str();
@@ -398,7 +378,6 @@ const char* cPVRClientNextPVR::GetBackendName(void)
 
 const char* cPVRClientNextPVR::GetBackendVersion()
 {
-  LOG_API_CALL(__FUNCTION__);
   if (!m_bConnected)
     return "Unknown";
 
@@ -415,7 +394,6 @@ const char* cPVRClientNextPVR::GetConnectionString(void)
 
 PVR_ERROR cPVRClientNextPVR::GetDriveSpace(long long* iTotal, long long* iUsed)
 {
-  LOG_API_CALL(__FUNCTION__);
   string result;
   vector<string> fields;
 
@@ -445,8 +423,6 @@ unsigned int cPVRClientNextPVR::XmlGetUInt(TiXmlElement* node, const char* name,
 
 PVR_ERROR cPVRClientNextPVR::GetChannelStreamProperties(const PVR_CHANNEL& channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
 {
-  LOG_API_CALL(__FUNCTION__);
-  XBMC->Log(LOG_DEBUG, "%s:%d:", __FUNCTION__, __LINE__);
   bool liveStream = m_channels.IsChannelAPlugin(channel.iUniqueId);
   if (liveStream || (m_settings.m_liveStreamingMethod == Transcoded && !channel.bIsRadio))
   {
@@ -495,7 +471,6 @@ PVR_ERROR cPVRClientNextPVR::GetChannelStreamProperties(const PVR_CHANNEL& chann
 bool cPVRClientNextPVR::OpenLiveStream(const PVR_CHANNEL& channelinfo)
 {
   std::string line;
-  LOG_API_CALL(__FUNCTION__);
   if (channelinfo.bIsRadio == false)
   {
     m_nowPlaying = TV;
@@ -540,21 +515,17 @@ bool cPVRClientNextPVR::OpenLiveStream(const PVR_CHANNEL& channelinfo)
 
 int cPVRClientNextPVR::ReadLiveStream(unsigned char* pBuffer, unsigned int iBufferSize)
 {
-  LOG_API_CALL(__FUNCTION__);
   return m_livePlayer->Read(pBuffer, iBufferSize);
 }
 
 void cPVRClientNextPVR::CloseLiveStream(void)
 {
-  LOG_API_CALL(__FUNCTION__);
   XBMC->Log(LOG_DEBUG, "CloseLiveStream");
   if (m_livePlayer != nullptr)
   {
-    XBMC->Log(LOG_DEBUG, "CloseLiveStream");
     m_livePlayer->Close();
     m_livePlayer = nullptr;
   }
-  XBMC->Log(LOG_DEBUG, "CloseLiveStream@exit");
   m_nowPlaying = NotPlaying;
 }
 
@@ -562,7 +533,6 @@ void cPVRClientNextPVR::CloseLiveStream(void)
 long long cPVRClientNextPVR::SeekLiveStream(long long iPosition, int iWhence)
 {
   long long retVal;
-  LOG_API_CALL(__FUNCTION__);
   XBMC->Log(LOG_DEBUG, "calling seek(%lli %d)", iPosition, iWhence);
   retVal = m_livePlayer->Seek(iPosition, iWhence);
   XBMC->Log(LOG_DEBUG, "returned from seek()");
@@ -572,14 +542,12 @@ long long cPVRClientNextPVR::SeekLiveStream(long long iPosition, int iWhence)
 
 long long cPVRClientNextPVR::LengthLiveStream(void)
 {
-  LOG_API_CALL(__FUNCTION__);
   XBMC->Log(LOG_DEBUG, "seek length(%lli)", m_livePlayer->Length());
   return m_livePlayer->Length();
 }
 
 PVR_ERROR cPVRClientNextPVR::GetSignalStatus(PVR_SIGNAL_STATUS* signalStatus)
 {
-  LOG_API_CALL(__FUNCTION__);
   // Not supported yet
   if (m_nowPlaying == Transcoding)
   {
@@ -591,7 +559,6 @@ PVR_ERROR cPVRClientNextPVR::GetSignalStatus(PVR_SIGNAL_STATUS* signalStatus)
 
 bool cPVRClientNextPVR::CanPauseStream(void)
 {
-  LOG_API_CALL(__FUNCTION__);
   if (m_nowPlaying == Recording)
   {
     return true;
@@ -605,7 +572,6 @@ bool cPVRClientNextPVR::CanPauseStream(void)
 
 void cPVRClientNextPVR::PauseStream(bool bPaused)
 {
-  LOG_API_CALL(__FUNCTION__);
   if (m_nowPlaying == Recording)
     m_recordingBuffer->PauseStream(bPaused);
   else
@@ -614,7 +580,6 @@ void cPVRClientNextPVR::PauseStream(bool bPaused)
 
 bool cPVRClientNextPVR::CanSeekStream(void)
 {
-  LOG_API_CALL(__FUNCTION__);
   if (m_nowPlaying == Recording)
     return true;
   else
@@ -628,7 +593,6 @@ bool cPVRClientNextPVR::CanSeekStream(void)
 bool cPVRClientNextPVR::OpenRecordedStream(const PVR_RECORDING& recording)
 {
   PVR_RECORDING copyRecording = recording;
-  LOG_API_CALL(__FUNCTION__);
   m_nowPlaying = Recording;
   strcpy(copyRecording.strDirectory, m_recordings.m_hostFilenames[recording.strRecordingId].c_str());
   const std::string line = StringUtils::Format("http://%s:%d/live?recording=%s&client=XBMC-%s", m_settings.m_hostname.c_str(), m_settings.m_port, recording.strRecordingId, m_sid);
@@ -637,7 +601,6 @@ bool cPVRClientNextPVR::OpenRecordedStream(const PVR_RECORDING& recording)
 
 void cPVRClientNextPVR::CloseRecordedStream(void)
 {
-  LOG_API_CALL(__FUNCTION__);
   m_recordingBuffer->Close();
   m_recordingBuffer->SetDuration(0);
   m_nowPlaying = NotPlaying;
@@ -645,26 +608,22 @@ void cPVRClientNextPVR::CloseRecordedStream(void)
 
 int cPVRClientNextPVR::ReadRecordedStream(unsigned char* pBuffer, unsigned int iBufferSize)
 {
-  LOG_API_CALL(__FUNCTION__);
   iBufferSize = m_recordingBuffer->Read(pBuffer, iBufferSize);
   return iBufferSize;
 }
 
 long long cPVRClientNextPVR::SeekRecordedStream(long long iPosition, int iWhence)
 {
-  LOG_API_CALL(__FUNCTION__);
   return m_recordingBuffer->Seek(iPosition, iWhence);
 }
 
 long long cPVRClientNextPVR::LengthRecordedStream(void)
 {
-  LOG_API_CALL(__FUNCTION__);
   return m_recordingBuffer->Length();
 }
 
 bool cPVRClientNextPVR::IsTimeshifting()
 {
-  LOG_API_CALL(__FUNCTION__);
   if (m_nowPlaying == Recording)
     return false;
   else
@@ -673,7 +632,6 @@ bool cPVRClientNextPVR::IsTimeshifting()
 
 bool cPVRClientNextPVR::IsRealTimeStream()
 {
-  LOG_API_CALL(__FUNCTION__);
   bool retval;
   if (m_nowPlaying == Recording)
   {
@@ -689,17 +647,10 @@ bool cPVRClientNextPVR::IsRealTimeStream()
 PVR_ERROR cPVRClientNextPVR::GetStreamTimes(PVR_STREAM_TIMES* stimes)
 {
   PVR_ERROR rez;
-  LOG_API_CALL(__FUNCTION__);
   if (m_nowPlaying == Recording)
     rez = m_recordingBuffer->GetStreamTimes(stimes);
   else
     rez = m_livePlayer->GetStreamTimes(stimes);
-#if DEBUGGING_API
-  XBMC->Log(LOG_ERROR, "GetStreamTimes: start: %d", stimes->startTime);
-  XBMC->Log(LOG_ERROR, "             ptsStart: %lld", stimes->ptsStart);
-  XBMC->Log(LOG_ERROR, "             ptsBegin: %lld", stimes->ptsBegin);
-  XBMC->Log(LOG_ERROR, "               ptsEnd: %lld", stimes->ptsEnd);
-#endif
   return rez;
 }
 
@@ -712,7 +663,5 @@ PVR_ERROR cPVRClientNextPVR::GetStreamReadChunkSize(int* chunksize)
     *chunksize = 4096;
   else
     rez = m_livePlayer->GetStreamReadChunkSize(chunksize);
-
-  LOG_API_IRET(__FUNCTION__, *chunksize);
   return rez;
 }

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -139,70 +139,6 @@ cPVRClientNextPVR::~cPVRClientNextPVR()
   m_channels.m_liveStreams.clear();
 }
 
-PVR_ERROR cPVRClientNextPVR::CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA& item)
-{
-  if (item.cat == PVR_MENUHOOK_CHANNEL && menuhook.iHookId == PVR_MENUHOOK_CHANNEL_DELETE_SINGLE_CHANNEL_ICON)
-  {
-    m_channels.DeleteChannelIcon(item.data.channel.iUniqueId);
-    PVR->TriggerChannelUpdate();
-  }
-  else if (item.cat == PVR_MENUHOOK_RECORDING && menuhook.iHookId == PVR_MENUHOOK_RECORDING_FORGET_RECORDING)
-  {
-    m_recordings.ForgetRecording(item.data.recording);
-  }
-  else if (item.cat == PVR_MENUHOOK_SETTING && menuhook.iHookId == PVR_MENUHOOK_SETTING_DELETE_ALL_CHANNNEL_ICONS)
-  {
-    m_channels.DeleteChannelIcons();
-    PVR->TriggerChannelUpdate();
-  }
-  else if (item.cat == PVR_MENUHOOK_SETTING && menuhook.iHookId == PVR_MENUHOOK_SETTING_UPDATE_CHANNNELS)
-  {
-    PVR->TriggerChannelUpdate();
-  }
-  else if (item.cat == PVR_MENUHOOK_SETTING && menuhook.iHookId == PVR_MENUHOOK_SETTING_UPDATE_CHANNNEL_GROUPS)
-  {
-    PVR->TriggerChannelGroupsUpdate();
-  }
-  return PVR_ERROR_NO_ERROR;
-}
-
-void cPVRClientNextPVR::ConfigureMenuhook()
-{
-  PVR_MENUHOOK menuHook;
-  menuHook = {0};
-  menuHook.category = PVR_MENUHOOK_CHANNEL;
-  menuHook.iHookId = PVR_MENUHOOK_CHANNEL_DELETE_SINGLE_CHANNEL_ICON;
-  menuHook.iLocalizedStringId = 30183;
-  PVR->AddMenuHook(&menuHook);
-
-  menuHook = {0};
-  menuHook.category = PVR_MENUHOOK_SETTING;
-  menuHook.iHookId = PVR_MENUHOOK_SETTING_DELETE_ALL_CHANNNEL_ICONS;
-  menuHook.iLocalizedStringId = 30170;
-  PVR->AddMenuHook(&menuHook);
-
-  menuHook = {0};
-  menuHook.category = PVR_MENUHOOK_SETTING;
-  menuHook.iHookId = PVR_MENUHOOK_SETTING_UPDATE_CHANNNELS;
-  menuHook.iLocalizedStringId = 30185;
-  PVR->AddMenuHook(&menuHook);
-
-  menuHook = {0};
-  menuHook.category = PVR_MENUHOOK_SETTING;
-  menuHook.iHookId = PVR_MENUHOOK_SETTING_UPDATE_CHANNNEL_GROUPS;
-  menuHook.iLocalizedStringId = 30186;
-  PVR->AddMenuHook(&menuHook);
-
-  if (m_settings.m_backendVersion >= 50000)
-  {
-    menuHook = {0};
-    menuHook.category = PVR_MENUHOOK_RECORDING;
-    menuHook.iHookId = PVR_MENUHOOK_RECORDING_FORGET_RECORDING;
-    menuHook.iLocalizedStringId = 30184;
-    PVR->AddMenuHook(&menuHook);
-  }
-}
-
 ADDON_STATUS cPVRClientNextPVR::Connect()
 {
   string result;
@@ -215,7 +151,7 @@ ADDON_STATUS cPVRClientNextPVR::Connect()
   if (m_request.DoRequest("/service?method=session.initiate&ver=1.0&device=xbmc", response) == HTTP_OK)
   {
     TiXmlDocument doc;
-    if (doc.Parse(response.c_str()) != NULL)
+    if (doc.Parse(response.c_str()) != nullptr)
     {
       std::string salt;
       std::string sid;
@@ -273,7 +209,7 @@ ADDON_STATUS cPVRClientNextPVR::Connect()
   }
   else
   {
-    PVR->ConnectionStateChange("Could not connect to server", PVR_CONNECTION_STATE_SERVER_UNREACHABLE, NULL);
+    PVR->ConnectionStateChange("Could not connect to server", PVR_CONNECTION_STATE_SERVER_UNREACHABLE, nullptr);
     status = ADDON_STATUS_PERMANENT_FAILURE;
   }
 
@@ -290,7 +226,7 @@ void cPVRClientNextPVR::Disconnect()
 void cPVRClientNextPVR::ConfigurePostConnectionOptions()
 {
   m_settings.SetVersionSpecificSettings();
-  ConfigureMenuhook();
+  m_menuhook.ConfigureMenuHook();
   if (m_settings.m_liveStreamingMethod != eStreamingMethod::RealTime)
   {
     delete m_timeshiftBuffer;
@@ -338,10 +274,10 @@ bool cPVRClientNextPVR::IsUp()
     std::string response;
     if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
     {
-      if (doc.Parse(response.c_str()) != NULL)
+      if (doc.Parse(response.c_str()) != nullptr)
       {
         TiXmlElement* last_update = doc.RootElement()->FirstChildElement("last_update");
-        if (last_update != NULL)
+        if (last_update != nullptr)
         {
           int64_t update_time = atoll(last_update->GetText());
           if (update_time > m_lastRecordingUpdateTime)
@@ -386,26 +322,26 @@ void* cPVRClientNextPVR::Process(void)
     IsUp();
     Sleep(2500);
   }
-  return NULL;
+  return nullptr;
 }
 
 void cPVRClientNextPVR::OnSystemSleep()
 {
   m_lastRecordingUpdateTime = MAXINT64;
   Disconnect();
-  PVR->ConnectionStateChange("sleeping", PVR_CONNECTION_STATE_DISCONNECTED, NULL);
+  PVR->ConnectionStateChange("sleeping", PVR_CONNECTION_STATE_DISCONNECTED, nullptr);
   Sleep(1000);
 }
 
 void cPVRClientNextPVR::OnSystemWake()
 {
-  PVR->ConnectionStateChange("waking", PVR_CONNECTION_STATE_CONNECTING, NULL);
+  PVR->ConnectionStateChange("waking", PVR_CONNECTION_STATE_CONNECTING, nullptr);
   int count = 0;
   for (; count < 5; count++)
   {
     if (Connect())
     {
-      PVR->ConnectionStateChange("connected", PVR_CONNECTION_STATE_CONNECTED, NULL);
+      PVR->ConnectionStateChange("connected", PVR_CONNECTION_STATE_CONNECTED, nullptr);
       break;
     }
     Sleep(500);

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -39,17 +39,6 @@
     delete (p); \
     (p) = nullptr; \
   } while (0)
-#define DEBUGGING_XML 0
-
-#define DEBUGGING_API 0
-#if DEBUGGING_API
-#define LOG_API_CALL(f) XBMC->Log(LOG_INFO, "%s:  called!", f)
-#define LOG_API_IRET(f, i) XBMC->Log(LOG_INFO, "%s: returns %d", f, i)
-#else
-#define LOG_API_CALL(f)
-#define LOG_API_IRET(f, i)
-#endif
-
 
 enum eNowPlaying
 {

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -11,66 +11,49 @@
 #include <vector>
 
 /* Master defines for client control */
-#include "kodi/xbmc_pvr_types.h"
 #include "kodi/libXBMC_addon.h"
+#include "kodi/xbmc_pvr_types.h"
 
 /* Local includes */
+
+#include "Channels.h"
+#include "EPG.h"
+#include "Recordings.h"
 #include "Settings.h"
+#include "Timers.h"
+#include "buffers/ClientTimeshift.h"
 #include "buffers/DummyBuffer.h"
-#include "buffers/TranscodedBuffer.h"
-#include "buffers/TimeshiftBuffer.h"
 #include "buffers/RecordingBuffer.h"
 #include "buffers/RollingFile.h"
-#include "buffers/ClientTimeshift.h"
-
+#include "buffers/TimeshiftBuffer.h"
+#include "buffers/TranscodedBuffer.h"
 #include "p8-platform/threads/mutex.h"
 #include "p8-platform/threads/threads.h"
 #include "tinyxml.h"
 #include <map>
 
-#define SAFE_DELETE(p)       do { delete (p);     (p)=NULL; } while (0)
-
+#define SAFE_DELETE(p) \
+  do \
+  { \
+    delete (p); \
+    (p) = NULL; \
+  } while (0)
+#define DEBUGGING_XML 0
 #define PVR_MENUHOOK_CHANNEL_DELETE_SINGLE_CHANNEL_ICON 101
 #define PVR_MENUHOOK_RECORDING_FORGET_RECORDING 401
 #define PVR_MENUHOOK_SETTING_DELETE_ALL_CHANNNEL_ICONS 601
 #define PVR_MENUHOOK_SETTING_UPDATE_CHANNNELS 602
 #define PVR_MENUHOOK_SETTING_UPDATE_CHANNNEL_GROUPS 603
 
-/* timer type ids */
-#define TIMER_MANUAL_MIN          (PVR_TIMER_TYPE_NONE + 1)
-#define TIMER_ONCE_MANUAL         (TIMER_MANUAL_MIN + 0)
-#define TIMER_ONCE_EPG            (TIMER_MANUAL_MIN + 1)
-#define TIMER_ONCE_KEYWORD        (TIMER_MANUAL_MIN + 2)
-#define TIMER_ONCE_MANUAL_CHILD   (TIMER_MANUAL_MIN + 3)
-#define TIMER_ONCE_EPG_CHILD      (TIMER_MANUAL_MIN + 4)
-#define TIMER_ONCE_KEYWORD_CHILD  (TIMER_MANUAL_MIN + 5)
-#define TIMER_MANUAL_MAX          (TIMER_MANUAL_MIN + 5)
+#define DEBUGGING_API 0
+#if DEBUGGING_API
+#define LOG_API_CALL(f) XBMC->Log(LOG_INFO, "%s:  called!", f)
+#define LOG_API_IRET(f, i) XBMC->Log(LOG_INFO, "%s: returns %d", f, i)
+#else
+#define LOG_API_CALL(f)
+#define LOG_API_IRET(f, i)
+#endif
 
-#define TIMER_REPEATING_MIN       (TIMER_MANUAL_MAX + 1)
-#define TIMER_REPEATING_MANUAL    (TIMER_REPEATING_MIN + 0)
-#define TIMER_REPEATING_EPG       (TIMER_REPEATING_MIN + 1)
-#define TIMER_REPEATING_KEYWORD   (TIMER_REPEATING_MIN + 2)
-#define TIMER_REPEATING_ADVANCED  (TIMER_REPEATING_MIN + 3)
-#define TIMER_REPEATING_MAX       (TIMER_REPEATING_MIN + 3)
-
-typedef enum
-{
-  NEXTPVR_SHOWTYPE_ANY = 0,
-  NEXTPVR_SHOWTYPE_FIRSTRUNONLY = 1,
-} nextpvr_showtype_t;
-
-typedef enum
-{
-  NEXTPVR_LIMIT_ASMANY = 0,
-  NEXTPVR_LIMIT_1 = 1,
-  NEXTPVR_LIMIT_2 = 2,
-  NEXTPVR_LIMIT_3 = 3,
-  NEXTPVR_LIMIT_4 = 4,
-  NEXTPVR_LIMIT_5 = 5,
-  NEXTPVR_LIMIT_6 = 6,
-  NEXTPVR_LIMIT_7 = 7,
-  NEXTPVR_LIMIT_10 = 10
-} nextpvr_recordinglimit_t;
 
 enum eNowPlaying
 {
@@ -94,61 +77,28 @@ public:
   bool IsUp();
   void OnSystemSleep();
   void OnSystemWake();
-  void LoadLiveStreams();
 
   /* General handling */
   const char* GetBackendName(void);
   const char* GetBackendVersion();
   const char* GetConnectionString(void);
-  PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed);
-  PVR_ERROR GetBackendTime(time_t *localTime, int *gmtOffset);
-  PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *stimes);
+  PVR_ERROR GetDriveSpace(long long* iTotal, long long* iUsed);
+  PVR_ERROR GetBackendTime(time_t* localTime, int* gmtOffset);
+  PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES* stimes);
   PVR_ERROR GetStreamReadChunkSize(int* chunksize);
-  int XmlGetInt(TiXmlElement * node, const char* name);
+  int XmlGetInt(TiXmlElement* node, const char* name, const int setDefault = 0);
+  unsigned int XmlGetUInt(TiXmlElement* node, const char* name, const unsigned setDefault = 0);
   PVR_ERROR CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA& item);
   void ConfigureMenuhook();
 
-  /* EPG handling */
-  PVR_ERROR GetEpg(ADDON_HANDLE handle, int iChannelUid, time_t iStart = 0, time_t iEnd = 0);
-
-  /* Channel handling */
-  int GetNumChannels(void);
-  PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
-  PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL &channel, PVR_NAMED_VALUE *properties, unsigned int *iPropertiesCount);
+  PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL& channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount);
   bool IsChannelAPlugin(int uid);
 
-  /* Channel group handling */
-  int GetChannelGroupsAmount(void);
-  PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio);
-  PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
-
-  /* Record handling **/
-  int GetNumRecordings(void);
-  PVR_ERROR GetRecordings(ADDON_HANDLE handle);
-  PVR_ERROR DeleteRecording(const PVR_RECORDING &recording);
-  PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition);
-  int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording);
-  PVR_ERROR GetRecordingEdl(const PVR_RECORDING& recording, PVR_EDL_ENTRY[], int *size);
-  PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*);
-  bool UpdatePvrRecording(TiXmlElement* pRecordingNode, PVR_RECORDING *tag, const std::string& title, bool flatten);
-  void ParseNextPVRSubtitle( const char *episodeName, PVR_RECORDING   *tag);
-  bool ForgetRecording(const PVR_RECORDING& recording);
-
-  /* Timer handling */
-  int GetNumTimers(void);
-  PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size);
-  PVR_ERROR GetTimers(ADDON_HANDLE handle);
-  PVR_ERROR GetTimerInfo(unsigned int timernumber, PVR_TIMER &timer);
-  PVR_ERROR AddTimer(const PVR_TIMER &timer);
-  PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete = false);
-  PVR_ERROR UpdateTimer(const PVR_TIMER &timer);
-  bool UpdatePvrTimer(TiXmlElement* pRecordingNode, PVR_TIMER *tag);
-
   /* Live stream handling */
-  bool OpenLiveStream(const PVR_CHANNEL &channel);
+  bool OpenLiveStream(const PVR_CHANNEL& channel);
   void CloseLiveStream();
-  int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize);
-  PVR_ERROR GetSignalStatus(PVR_SIGNAL_STATUS *signalStatus);
+  int ReadLiveStream(unsigned char* pBuffer, unsigned int iBufferSize);
+  PVR_ERROR GetSignalStatus(PVR_SIGNAL_STATUS* signalStatus);
   long long SeekLiveStream(long long iPosition, int iWhence = SEEK_SET);
   long long LengthLiveStream(void);
   bool CanPauseStream(void);
@@ -158,26 +108,29 @@ public:
   bool IsRealTimeStream(void);
 
   /* Record stream handling */
-  bool OpenRecordedStream(const PVR_RECORDING &recording);
+  bool OpenRecordedStream(const PVR_RECORDING& recording);
   void CloseRecordedStream(void);
-  int ReadRecordedStream(unsigned char *pBuffer, unsigned int iBufferSize);
+  int ReadRecordedStream(unsigned char* pBuffer, unsigned int iBufferSize);
   long long SeekRecordedStream(long long iPosition, int iWhence = SEEK_SET);
   long long LengthRecordedStream(void);
-  void ForceRecordingUpdate() { m_lastRecordingUpdateTime = 0;}
+  void ForceRecordingUpdate() { m_lastRecordingUpdateTime = 0; }
 
   /* background connection monitoring */
-  void *Process(void);
+  void* Process(void);
+
+  Channels& m_channels = Channels::GetInstance();
+  EPG& m_epg = EPG::GetInstance();
+  Recordings& m_recordings = Recordings::GetInstance();
+  Timers& m_timers = Timers::GetInstance();
+  int64_t m_lastRecordingUpdateTime;
+  char m_sid[64];
 
 protected:
-  NextPVR::Socket           *m_tcpclient;
-  NextPVR::Socket           *m_streamingclient;
 
 private:
-  std::string GetDayString(int dayMask);
-  std::vector<std::string> split(const std::string& s, const std::string& delim, const bool keep_empty);
-  bool GetChannel(unsigned int number, PVR_CHANNEL &channeldata);
-  bool LoadGenreXML(const std::string &filename);
-  int DoRequest(const char *resource, std::string &response);
+  bool GetChannel(unsigned int number, PVR_CHANNEL& channeldata);
+  bool LoadGenreXML(const std::string& filename);
+
   std::string GetChannelIcon(int channelID);
   std::string GetChannelIconFileName(int channelID);
   void DeleteChannelIcon(int channelID);
@@ -186,51 +139,28 @@ private:
 
   void Close();
 
-  int                     m_iCurrentChannel;
-  bool                    m_bConnected;
-  std::string             m_BackendName;
-  P8PLATFORM::CMutex      m_mutex;
+  bool m_bConnected;
+  std::string m_BackendName;
+  P8PLATFORM::CMutex m_mutex;
 
-  long long               m_currentRecordingLength;
-  long long               m_currentRecordingPosition;
+  bool m_supportsLiveTimeshift;
 
-  bool                    m_supportsLiveTimeshift;
-  long long               m_currentLiveLength;
-  long long               m_currentLivePosition;
-
-  int64_t                 m_lastRecordingUpdateTime;
-
-  char                    m_sid[64];
-
-  // update these at end of counting loop can be called during action
-  int                     m_iRecordingCount = -1;
-  int                     m_iTimerCount = -1;
-
-  int                     m_defaultLimit;
-  int                     m_defaultShowType;
-  time_t                  m_tsbStartTime;
-  int                     m_timeShiftBufferSeconds;
-  timeshift::Buffer      *m_timeshiftBuffer;
-  timeshift::Buffer      *m_livePlayer;
-  timeshift::Buffer      *m_realTimeBuffer;
-  timeshift::RecordingBuffer *m_recordingBuffer;
-
-  std::map<std::string, std::string> m_hostFilenames;
-  std::map<int, std::string> m_liveStreams;
+  time_t m_tsbStartTime;
+  int m_timeShiftBufferSeconds;
+  timeshift::Buffer* m_timeshiftBuffer;
+  timeshift::Buffer* m_livePlayer;
+  timeshift::Buffer* m_realTimeBuffer;
+  timeshift::RecordingBuffer* m_recordingBuffer;
 
   //Matrix changes
   NextPVR::Settings& m_settings = NextPVR::Settings::GetInstance();
   NextPVR::Request& m_request = NextPVR::Request::GetInstance();
-  std::map<std::string,int> m_epgOidLookup;
+
   eNowPlaying m_nowPlaying = NotPlaying;
-  std::map<int, std::pair<bool, bool>> m_channelDetails;
 
   void SendWakeOnLan();
 
   PVR_RECORDING_CHANNEL_TYPE GetChannelType(unsigned int uid);
 
-  bool GetAdditiveString(const TiXmlNode* pRootNode, const char* strTag,
-        const std::string& strSeparator, std::string& strStringValue,
-        bool clear);
-
 };
+

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -18,6 +18,7 @@
 
 #include "Channels.h"
 #include "EPG.h"
+#include "MenuHook.h"
 #include "Recordings.h"
 #include "Settings.h"
 #include "Timers.h"
@@ -36,14 +37,9 @@
   do \
   { \
     delete (p); \
-    (p) = NULL; \
+    (p) = nullptr; \
   } while (0)
 #define DEBUGGING_XML 0
-#define PVR_MENUHOOK_CHANNEL_DELETE_SINGLE_CHANNEL_ICON 101
-#define PVR_MENUHOOK_RECORDING_FORGET_RECORDING 401
-#define PVR_MENUHOOK_SETTING_DELETE_ALL_CHANNNEL_ICONS 601
-#define PVR_MENUHOOK_SETTING_UPDATE_CHANNNELS 602
-#define PVR_MENUHOOK_SETTING_UPDATE_CHANNNEL_GROUPS 603
 
 #define DEBUGGING_API 0
 #if DEBUGGING_API
@@ -88,8 +84,6 @@ public:
   PVR_ERROR GetStreamReadChunkSize(int* chunksize);
   int XmlGetInt(TiXmlElement* node, const char* name, const int setDefault = 0);
   unsigned int XmlGetUInt(TiXmlElement* node, const char* name, const unsigned setDefault = 0);
-  PVR_ERROR CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA& item);
-  void ConfigureMenuhook();
 
   PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL& channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount);
   bool IsChannelAPlugin(int uid);
@@ -120,6 +114,7 @@ public:
 
   Channels& m_channels = Channels::GetInstance();
   EPG& m_epg = EPG::GetInstance();
+  MenuHook& m_menuhook = MenuHook::GetInstance();
   Recordings& m_recordings = Recordings::GetInstance();
   Timers& m_timers = Timers::GetInstance();
   int64_t m_lastRecordingUpdateTime;
@@ -163,4 +158,3 @@ private:
   PVR_RECORDING_CHANNEL_TYPE GetChannelType(unsigned int uid);
 
 };
-


### PR DESCRIPTION
Change pvrclient from monolithic code model.   C++ from C, remove PVR_STRCPY, sprintf when feasible, remove raw tinyxml.  Remove dead and debug code.  Processed with clang-format 