### PR TITLE
5.0.3  Timer changes

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="5.0.2"
+  version="5.0.3"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,8 @@
+v5.0.3
+- Recording types 1 and 2 should start/end anytime
+- Set start and end time on timeslot recordings
+- Indicate disabled timers
+
 v5.0.2
 - Open most streams with the proper READ_NO_CACHE value
 - Move MenuHook to one time call, avoid issue OnWake


### PR DESCRIPTION
Start and end times not being set correctly on any time type 1 and 2.    Set the original time on timeslot recording.