### PR TITLE
6.0.1 ConnectionStateChange

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="6.0.0"
+  version="6.0.1"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,7 @@
+v6.0.1
+- ConnectionStateChange needs a string message
+- assign menuhooks on success only
+
 v6.0.0
 - Change to C++ interface
 - Update PVR API 7.0.0

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -54,9 +54,8 @@ ADDON_STATUS CNextPVRAddon::CreateInstance(int instanceType,
   {
     addonInstance = g_pvrclient;
     m_usedInstances.emplace(std::make_pair(instanceID, g_pvrclient));
+    g_pvrclient->m_menuhook.ConfigureMenuHook();
   }
-
-  g_pvrclient->m_menuhook.ConfigureMenuHook();
 
   return m_CurStatus;
 }

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -181,7 +181,7 @@ ADDON_STATUS cPVRClientNextPVR::Connect()
   }
   else
   {
-    g_pvrclient->ConnectionStateChange("Could not connect to server", PVR_CONNECTION_STATE_SERVER_UNREACHABLE, nullptr);
+    g_pvrclient->ConnectionStateChange("Could not connect to server", PVR_CONNECTION_STATE_SERVER_UNREACHABLE, "");
     status = ADDON_STATUS_PERMANENT_FAILURE;
   }
 
@@ -292,20 +292,20 @@ PVR_ERROR cPVRClientNextPVR::OnSystemSleep()
 {
   m_lastRecordingUpdateTime = MAXINT64;
   Disconnect();
-  g_pvrclient->ConnectionStateChange("sleeping", PVR_CONNECTION_STATE_DISCONNECTED, nullptr);
+  g_pvrclient->ConnectionStateChange("sleeping", PVR_CONNECTION_STATE_DISCONNECTED, "");
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   return PVR_ERROR_NO_ERROR;
 }
 
 PVR_ERROR cPVRClientNextPVR::OnSystemWake()
 {
-  g_pvrclient->ConnectionStateChange("waking", PVR_CONNECTION_STATE_CONNECTING, nullptr);
+  g_pvrclient->ConnectionStateChange("waking", PVR_CONNECTION_STATE_CONNECTING, "");
   int count = 0;
   for (; count < 5; count++)
   {
     if (Connect())
     {
-      g_pvrclient->ConnectionStateChange("connected", PVR_CONNECTION_STATE_CONNECTED, nullptr);
+      g_pvrclient->ConnectionStateChange("connected", PVR_CONNECTION_STATE_CONNECTED, "");
       break;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(500));


### PR DESCRIPTION
After the c++ conversion, the ConnectionStateChange() message parameter must be a string,  and an empty string is needed to use the default string.  Menuhook was always being attached even when the client didn't connect