### PR TITLE
Get rid of external kodiplatform dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,10 @@ project(pvr.nextpvr)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(TinyXML REQUIRED)
 
 include_directories(${p8-platform_INCLUDE_DIRS}
-                    ${kodiplatform_INCLUDE_DIRS}
                     ${TINYXML_INCLUDE_DIR}
                     ${KODI_INCLUDE_DIR}/..) # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
 
@@ -57,10 +55,10 @@ set(NEXTPVR_HEADERS src/addon.h
                     src/buffers/RecordingBuffer.h
                     src/buffers/CircularBuffer.h
                     src/buffers/RollingFile.h
-                    src/buffers/Seeker.h)
+                    src/buffers/Seeker.h
+                    src/utilities/XMLUtils.h)
 
 SET(DEPLIBS ${p8-platform_LIBRARIES}
-            ${kodiplatform_LIBRARIES}
             ${TINYXML_LIBRARIES})
 if(WIN32)
   list(APPEND DEPLIBS ws2_32)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-nextpvr
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml-dev,
-               libkodiplatform-dev (>= 16.0.0), kodi-addon-dev
+               kodi-addon-dev
 Standards-Version: 4.1.2
 Section: libs
 Homepage: http://www.nextpvr.com

--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="6.0.3"
+  version="6.0.4"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v6.0.4
+- Get rid of external kodiplatform dependency
+
 v6.0.3
 - Optionally use timeshifted transcoded streaming via inputstream.ffmpegdirect
 - Fix for incorect OnSystemWake loop exit after c++ conversion change

--- a/src/Channels.cpp
+++ b/src/Channels.cpp
@@ -7,12 +7,13 @@
  */
 
 #include "Channels.h"
-#include "kodi/util/XMLUtils.h"
+#include "utilities/XMLUtils.h"
 #include "pvrclient-nextpvr.h"
 
 #include <p8-platform/util/StringUtils.h>
 
 using namespace NextPVR;
+using namespace NextPVR::utilities;
 
 /** Channel handling */
 

--- a/src/EPG.cpp
+++ b/src/EPG.cpp
@@ -8,12 +8,13 @@
 
 #include "EPG.h"
 
-#include "kodi/util/XMLUtils.h"
 #include "pvrclient-nextpvr.h"
+#include "utilities/XMLUtils.h"
 
 #include <p8-platform/util/StringUtils.h>
 
 using namespace NextPVR;
+using namespace NextPVR::utilities;
 
 /************************************************************/
 /** EPG handling */

--- a/src/Recordings.cpp
+++ b/src/Recordings.cpp
@@ -7,8 +7,8 @@
  */
 
 #include "Recordings.h"
+#include "utilities/XMLUtils.h"
 
-#include "kodi/util/XMLUtils.h"
 #include <kodi/General.h>
 #include "pvrclient-nextpvr.h"
 
@@ -17,6 +17,7 @@
 #include <p8-platform/util/StringUtils.h>
 
 using namespace NextPVR;
+using namespace NextPVR::utilities;
 
 /************************************************************/
 /** Record handling **/

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -10,12 +10,14 @@
 #include "Settings.h"
 #include "BackendRequest.h"
 #include "uri.h"
+#include "utilities/XMLUtils.h"
+
 #include <kodi/General.h>
-#include <kodi/util/XMLUtils.h>
 #include <p8-platform/util/StringUtils.h>
 #include <tinyxml.h>
 
 using namespace NextPVR;
+using namespace NextPVR::utilities;
 
 /***************************************************************************
  * PVR settings

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -7,13 +7,15 @@
  */
 
 #include "Timers.h"
+#include "utilities/XMLUtils.h"
+
 #include "pvrclient-nextpvr.h"
-#include "kodi/util/XMLUtils.h"
 #include <kodi/General.h>
 #include <p8-platform/util/StringUtils.h>
 #include <string>
 
 using namespace NextPVR;
+using namespace NextPVR::utilities;
 
 /************************************************************/
 /** Timer handling */

--- a/src/buffers/ClientTimeshift.cpp
+++ b/src/buffers/ClientTimeshift.cpp
@@ -9,11 +9,12 @@
 
 #include "ClientTimeshift.h"
 #include  "../BackendRequest.h"
+#include "../utilities/XMLUtils.h"
 #include <kodi/General.h>
-#include "kodi/util/XMLUtils.h"
 #include "tinyxml.h"
 
 using namespace timeshift;
+using namespace NextPVR::utilities;
 
 bool ClientTimeShift::Open(const std::string inputUrl)
 {

--- a/src/buffers/RollingFile.cpp
+++ b/src/buffers/RollingFile.cpp
@@ -10,13 +10,14 @@
 #include "RollingFile.h"
 #include  "../BackendRequest.h"
 #include  "../pvrclient-nextpvr.h"
+#include "../utilities/XMLUtils.h"
 #include <regex>
 #include <mutex>
 #include "tinyxml.h"
-#include "util/XMLUtils.h"
 
 //#define TESTURL "d:/downloads/abc.ts"
 
+using namespace NextPVR::utilities;
 using namespace timeshift;
 
 /* Rolling File mode functions */

--- a/src/buffers/TranscodedBuffer.cpp
+++ b/src/buffers/TranscodedBuffer.cpp
@@ -8,12 +8,12 @@
 
 
 #include "TranscodedBuffer.h"
+#include "../utilities/XMLUtils.h"
 #include "tinyxml.h"
-#include "kodi/util/XMLUtils.h"
 #include <limits>
 
+using namespace NextPVR::utilities;
 using namespace timeshift;
-
 
 bool TranscodedBuffer::Open(const std::string inputUrl)
 {

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -9,7 +9,7 @@
 #include "pvrclient-nextpvr.h"
 
 #include "BackendRequest.h"
-#include "kodi/util/XMLUtils.h"
+#include "utilities/XMLUtils.h"
 #include "kodi/General.h"
 #include <kodi/Network.h>
 #include "md5.h"
@@ -20,6 +20,8 @@
 #include <stdlib.h>
 
 #include <p8-platform/util/StringUtils.h>
+
+using namespace NextPVR::utilities;
 
 #if defined(TARGET_WINDOWS)
 #define atoll(S) _atoi64(S)

--- a/src/utilities/XMLUtils.h
+++ b/src/utilities/XMLUtils.h
@@ -1,0 +1,488 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <tinyxml.h>
+#include <vector>
+
+namespace NextPVR
+{
+namespace utilities
+{
+namespace XMLUtils
+{
+
+//==============================================================================
+/// @brief Returns true if the encoding of the document is specified as as UTF-8
+///
+/// @param[in] strXML The XML file (embedded in a string) to check.
+/// @return true if UTF8
+///
+inline bool HasUTF8Declaration(const std::string& strXML)
+{
+  std::string test = strXML;
+  std::transform(test.begin(), test.end(), test.begin(), ::tolower);
+  // test for the encoding="utf-8" string
+  if (test.find("encoding=\"utf-8\"") != std::string::npos)
+    return true;
+  // TODO: test for plain UTF8 here?
+  return false;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief Check given tag on XML has a child.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag to check
+/// @return true if child present.
+///
+inline bool HasChild(const TiXmlNode* pRootNode, const std::string& strTag)
+{
+  const TiXmlElement* pElement = pRootNode->FirstChildElement(strTag);
+  if (!pElement)
+    return false;
+  const TiXmlNode* pNode = pElement->FirstChild();
+  return (pNode != nullptr);
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief Returns true if the encoding of the document is other then UTF-8.
+///
+/// @param[in] pDoc TinyXML related document field
+/// @param[in] strEncoding Returns the encoding of the document. Empty if UTF-8
+/// @return String of encoding if present and not UTF-8
+///
+inline bool GetEncoding(const TiXmlDocument* pDoc, std::string& strEncoding)
+{
+  const TiXmlNode* pNode = nullptr;
+  while ((pNode = pDoc->IterateChildren(pNode)) && pNode->Type() != TiXmlNode::TINYXML_DECLARATION)
+  {
+  }
+  if (!pNode)
+    return false;
+  const TiXmlDeclaration* pDecl = pNode->ToDeclaration();
+  if (!pDecl)
+    return false;
+  strEncoding = pDecl->Encoding();
+  std::transform(strEncoding.begin(), strEncoding.end(), strEncoding.begin(), ::toupper);
+
+  if (strEncoding == "UTF-8" || strEncoding == "UTF8")
+    strEncoding.clear();
+
+  return !strEncoding.empty(); // Other encoding then UTF8?
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a text string value stored inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed value from XML
+/// @return true if available and successfully done
+///
+inline bool GetString(const TiXmlNode* pRootNode, const std::string& strTag, std::string& value)
+{
+  const TiXmlElement* pElement = pRootNode->FirstChildElement(strTag);
+  if (!pElement)
+    return false;
+  const TiXmlNode* pNode = pElement->FirstChild();
+  if (pNode != nullptr)
+  {
+    value = pNode->Value();
+    return true;
+  }
+  value.clear();
+  return false;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a HEX formated integer string inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed value from XML
+/// @return true if available and successfully done
+///
+inline bool GetHex(const TiXmlNode* pRootNode, const std::string& strTag, uint32_t& value)
+{
+  const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
+  if (!pNode || !pNode->FirstChild())
+    return false;
+  value = strtoul(pNode->FirstChild()->Value(), nullptr, 16);
+  return true;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a 32 bit unsigned integer value stored inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed value from XML
+/// @return true if available and successfully done
+///
+inline bool GetUInt(const TiXmlNode* pRootNode, const std::string& strTag, uint32_t& value)
+{
+  const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
+  if (!pNode || !pNode->FirstChild())
+    return false;
+  value = atol(pNode->FirstChild()->Value());
+  return true;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a 32 bit integer value stored inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed value from XML
+/// @return true if available and successfully done
+///
+inline bool GetInt(const TiXmlNode* pRootNode, const std::string& strTag, int32_t& value)
+{
+  const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
+  if (!pNode || !pNode->FirstChild())
+    return false;
+  value = atoi(pNode->FirstChild()->Value());
+  return true;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a 32 bit integer value stored inside XML.
+///
+/// This can define min and max values if content out of wanted range.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed value from XML
+/// @param[in] min Minimal return value
+/// @param[in] max Maximal return value
+/// @return true if available and successfully done
+///
+inline bool GetInt(const TiXmlNode* pRootNode,
+                   const std::string& strTag,
+                   int32_t& value,
+                   const int32_t min,
+                   const int32_t max)
+{
+  if (GetInt(pRootNode, strTag, value))
+  {
+    if (value < min)
+      value = min;
+    if (value > max)
+      value = max;
+    return true;
+  }
+  return false;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a 64 bit integer value stored inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed value from XML
+/// @return true if available and successfully done
+///
+inline bool GetLong(const TiXmlNode* pRootNode, const std::string& strTag, int64_t& value)
+{
+  const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
+  if (!pNode || !pNode->FirstChild())
+    return false;
+  value = atoll(pNode->FirstChild()->Value());
+  return true;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a floating point value stored inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed value from XML
+/// @return true if available and successfully done
+///
+inline bool GetFloat(const TiXmlNode* pRootNode, const std::string& strTag, float& value)
+{
+  const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
+  if (!pNode || !pNode->FirstChild())
+    return false;
+  value = atof(pNode->FirstChild()->Value());
+  return true;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a floating point value stored inside XML.
+///
+/// This can define min and max values if content out of wanted range.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed value from XML
+/// @param[in] min Minimal return value
+/// @param[in] max Maximal return value
+/// @return true if available and successfully done
+///
+inline bool GetFloat(const TiXmlNode* pRootNode,
+                     const std::string& strTag,
+                     float& value,
+                     const float min,
+                     const float max)
+{
+  if (GetFloat(pRootNode, strTag, value))
+  { // check range
+    if (value < min)
+      value = min;
+    if (value > max)
+      value = max;
+    return true;
+  }
+  return false;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a double floating point value stored inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed value from XML
+/// @return true if available and successfully done
+///
+inline bool GetDouble(const TiXmlNode* pRootNode, const std::string& strTag, double& value)
+{
+  const TiXmlNode* node = pRootNode->FirstChild(strTag);
+  if (!node || !node->FirstChild())
+    return false;
+  value = atof(node->FirstChild()->Value());
+  return true;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a boolean value stored inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed value from XML
+/// @return true if available and successfully done
+///
+inline bool GetBoolean(const TiXmlNode* pRootNode, const std::string& strTag, bool& value)
+{
+  const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
+  if (!pNode || !pNode->FirstChild())
+    return false;
+  std::string strEnabled = pNode->FirstChild()->Value();
+  std::transform(strEnabled.begin(), strEnabled.end(), strEnabled.begin(), ::tolower);
+  if (strEnabled == "off" || strEnabled == "no" || strEnabled == "disabled" ||
+      strEnabled == "false" || strEnabled == "0")
+    value = false;
+  else
+  {
+    value = true;
+    if (strEnabled != "on" && strEnabled != "yes" && strEnabled != "enabled" &&
+        strEnabled != "true")
+      return false; // invalid bool switch - it's probably some other string.
+  }
+  return true;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To get a path value stored inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[out] value The readed path value from XML
+/// @return true if available and successfully done
+///
+inline bool GetPath(const TiXmlNode* pRootNode, const std::string& strTag, std::string& value)
+{
+  const TiXmlElement* pElement = pRootNode->FirstChildElement(strTag);
+  if (!pElement)
+    return false;
+
+  const TiXmlNode* pNode = pElement->FirstChild();
+  if (pNode != nullptr)
+  {
+    value = pNode->Value();
+    return true;
+  }
+  value.clear();
+  return false;
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To store a text string inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[in] value Value to store
+///
+inline void SetString(TiXmlNode* pRootNode, const std::string& strTag, const std::string& value)
+{
+  TiXmlElement newElement(strTag);
+  TiXmlNode* pNewNode = pRootNode->InsertEndChild(newElement);
+  if (pNewNode)
+  {
+    TiXmlText xmlValue(value);
+    pNewNode->InsertEndChild(xmlValue);
+  }
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To store a list of strings inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[in] arrayValue List with string values to store
+///
+inline void SetStringArray(TiXmlNode* pRootNode,
+                           const std::string& strTag,
+                           const std::vector<std::string>& arrayValue)
+{
+  for (const auto& value : arrayValue)
+    SetString(pRootNode, strTag, value);
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To store a HEX formated integer string inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[in] value Value to store
+///
+inline void SetHex(TiXmlNode* pRootNode, const std::string& strTag, uint32_t value)
+{
+  size_t size = snprintf(nullptr, 0, "%x", value) + 1;
+  std::unique_ptr<char[]> strValue(new char[size]);
+  snprintf(strValue.get(), size, "%x", value);
+  SetString(pRootNode, strTag, std::string(strValue.get(), strValue.get() + size - 1));
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To store a 32 bit unsigned integer value inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[in] value Value to store
+///
+inline void SetUInt(TiXmlNode* pRootNode, const std::string& strTag, uint32_t value)
+{
+  SetString(pRootNode, strTag, std::to_string(value));
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To store a 32 bit integer value inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[in] value Value to store
+///
+inline void SetInt(TiXmlNode* pRootNode, const std::string& strTag, int32_t value)
+{
+  SetString(pRootNode, strTag, std::to_string(value));
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To store a 64 bit integer value inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[in] value Value to store
+///
+inline void SetLong(TiXmlNode* pRootNode, const std::string& strTag, int64_t value)
+{
+  SetString(pRootNode, strTag, std::to_string(value));
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To store a floating point value inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[in] value Value to store
+///
+inline void SetFloat(TiXmlNode* pRootNode, const std::string& strTag, float value)
+{
+  SetString(pRootNode, strTag, std::to_string(value));
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To store a double floating point value inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[in] value Value to store
+///
+inline void SetDouble(TiXmlNode* pRootNode, const std::string& strTag, double value)
+{
+  SetString(pRootNode, strTag, std::to_string(value));
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To store a boolean value inside XML.
+///
+/// By use of "true" or "false" as string in XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[in] value Boolean value to store
+///
+inline void SetBoolean(TiXmlNode* pRootNode, const std::string& strTag, bool value)
+{
+  SetString(pRootNode, strTag, value ? "true" : "false");
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @brief To store a path value inside XML.
+///
+/// @param[in] pRootNode TinyXML related note field
+/// @param[in] strTag XML identification tag
+/// @param[in] value Path to store
+///
+inline void SetPath(TiXmlNode* pRootNode, const std::string& strTag, const std::string& value)
+{
+  const int path_version = 1;
+  TiXmlElement newElement(strTag);
+  newElement.SetAttribute("pathversion", path_version);
+  TiXmlNode* pNewNode = pRootNode->InsertEndChild(newElement);
+  if (pNewNode)
+  {
+    TiXmlText xmlValue(value);
+    pNewNode->InsertEndChild(xmlValue);
+  }
+}
+//------------------------------------------------------------------------------
+
+} /* namespace XMLUtils */
+} /* namespace utilities */
+} /* namespace NextPVR */


### PR DESCRIPTION
1. import XMLUtils.h from pvr.vuplus and change
   "namespace enigma2" to "namespace NextPVR"

2. Modify the includes with script:

HEADER_PATH=$(find $PWD/ -name XMLUtils.h)
git grep -l "XMLUtils.h" | while read FILE
do
  RELATIVE_PATH=$(realpath --relative-to=$(dirname $(readlink -f "$FILE")) "$HEADER_PATH")
  sed -i 's|["<]kodi/util/XMLUtils.h[>"]|"'$RELATIVE_PATH'"|' "$FILE"
done

3. Open the affected files manually and re-roder includes:

   nano $(git grep -l "XMLUtils\.h")

   Also add "using namespace NextPVR::utilities" and replace
   "XMLUtils::" with "xml::"

4. Remove libkodiplatform-dev form debian/control file

5. Remove kodiplatform fromCMakeLists.txt and add XMLUtils.h
   to local header list.