### PR TITLE
debian: add libp8-platform-dev as build-dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-nextpvr
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml-dev,
-               kodi-addon-dev
+               libp8-platform-dev, kodi-addon-dev
 Standards-Version: 4.1.2
 Section: libs
 Homepage: http://www.nextpvr.com

--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="6.0.4"
+  version="6.0.5"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v6.0.5
+- Add libp8-platform-dev as dependency
+
 v6.0.4
 - Get rid of external kodiplatform dependency
 


### PR DESCRIPTION
 * kodiplatform-dev has libp8-platform-dev as
   build-dependency so it was fetched by gbp.

@AlwinEsch 