### PR TITLE
Protect recording and live buffers

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="7.0.0"
+  version="7.0.1"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,8 @@
+v7.0.1
+- Protect against out media calls from Kodi on closed files
+- Formalize and test manual https support
+- Add new recording metadata (year, firstAired)
+
 v7.0.0
 - Update GUI API 5.15.0
 - Remove not used source file

--- a/pvr.nextpvr/resources/settings.xml
+++ b/pvr.nextpvr/resources/settings.xml
@@ -29,6 +29,14 @@
             <heading>30002</heading>
           </control>
         </setting>
+        <setting help="" id="hostprotocol" label="" type="string" option="hidden">
+          <level>4</level>
+          <default>http</default>
+          <control format="string" type="edit">
+            <heading></heading>
+            <hidden>true</hidden>
+          </control>
+        </setting>
       </group>
       <group id="8">
         <setting help="" id="wolenable" label="30163" type="boolean">

--- a/src/Recordings.cpp
+++ b/src/Recordings.cpp
@@ -243,6 +243,11 @@ bool Recordings::UpdatePvrRecording(const tinyxml2::XMLNode* pRecordingNode, kod
       }
     }
   }
+  tag.SetYear(XMLUtils::GetIntValue(pRecordingNode, "year"));
+
+  std::string original;
+  XMLUtils::GetString(pRecordingNode, "original", original);
+  tag.SetFirstAired(original);
 
   tag.SetLastPlayedPosition(XMLUtils::GetIntValue(pRecordingNode, "playback_position"));
   m_lastPlayed[std::stoi(tag.GetRecordingId())] = tag.GetLastPlayedPosition();

--- a/src/buffers/RecordingBuffer.cpp
+++ b/src/buffers/RecordingBuffer.cpp
@@ -60,7 +60,7 @@ bool RecordingBuffer::Open(const std::string inputUrl, const kodi::addon::PVRRec
     m_isLive = false;
   }
   m_recordingURL = inputUrl;
-  if (!recording.GetDirectory().empty())
+  if (!recording.GetDirectory().empty() && m_isLive == false)
   {
     std::string kodiDirectory = recording.GetDirectory();
     StringUtils::Replace(kodiDirectory, '\\', '/');
@@ -73,7 +73,7 @@ bool RecordingBuffer::Open(const std::string inputUrl, const kodi::addon::PVRRec
       m_recordingURL = kodiDirectory;
     }
   }
-  return Buffer::Open(m_recordingURL, m_isLive ?  ADDON_READ_NO_CACHE : ADDON_READ_CACHED);
+  return Buffer::Open(m_recordingURL, ADDON_READ_NO_CACHE);
 }
 
 ssize_t RecordingBuffer::Read(byte *buffer, size_t length)

--- a/src/buffers/RecordingBuffer.h
+++ b/src/buffers/RecordingBuffer.h
@@ -65,8 +65,8 @@ namespace timeshift {
     }
 
     virtual int Duration(void);
-    int GetDuration(void) { return m_Duration; kodi::Log(ADDON_LOG_ERROR, "XXXXX Duration set to %d XXXXX", m_Duration); }
-    void SetDuration(int duration) { m_Duration = duration; kodi::Log(ADDON_LOG_ERROR, "XXXXX Duration set to %d XXXXX", m_Duration); }
+    int GetDuration(void) { return m_Duration; kodi::Log(ADDON_LOG_ERROR, "Duration get %d", m_Duration); }
+    void SetDuration(int duration) { m_Duration = duration; kodi::Log(ADDON_LOG_ERROR, "Duration set to %d", m_Duration); }
 
    PVR_ERROR GetStreamReadChunkSize(int* chunksize)
     {

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -137,7 +137,6 @@ ADDON_STATUS cPVRClientNextPVR::Connect(bool sendWOL)
       {
         // a bit of debug
         kodi::Log(ADDON_LOG_DEBUG, "session.initiate returns: sid=%s salt=%s", sid.c_str(), salt.c_str());
-
         std::string pinMD5 = kodi::GetMD5(m_settings.m_PIN);
         StringUtils::ToLower(pinMD5);
 

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -580,13 +580,17 @@ bool cPVRClientNextPVR::OpenLiveStream(const kodi::addon::PVRChannel& channel)
 
 int cPVRClientNextPVR::ReadLiveStream(unsigned char* pBuffer, unsigned int iBufferSize)
 {
-  return m_livePlayer->Read(pBuffer, iBufferSize);
+  if (IsServerStreamingLive())
+  {
+    return m_livePlayer->Read(pBuffer, iBufferSize);
+  }
+  return -1;
 }
 
 void cPVRClientNextPVR::CloseLiveStream(void)
 {
   kodi::Log(ADDON_LOG_DEBUG, "CloseLiveStream");
-  if (m_livePlayer != nullptr)
+  if (IsServerStreamingLive())
   {
     m_livePlayer->Close();
     m_livePlayer = nullptr;
@@ -594,21 +598,23 @@ void cPVRClientNextPVR::CloseLiveStream(void)
   m_nowPlaying = NotPlaying;
 }
 
-
 int64_t cPVRClientNextPVR::SeekLiveStream(int64_t iPosition, int iWhence)
 {
-  int64_t retVal;
-  kodi::Log(ADDON_LOG_DEBUG, "calling seek(%lli %d)", iPosition, iWhence);
-  retVal = m_livePlayer->Seek(iPosition, iWhence);
-  kodi::Log(ADDON_LOG_DEBUG, "returned from seek()");
-  return retVal;
+  if (IsServerStreamingLive())
+  {
+    return m_livePlayer->Seek(iPosition, iWhence);
+  }
+  return -1;
 }
-
 
 int64_t cPVRClientNextPVR::LengthLiveStream(void)
 {
-  kodi::Log(ADDON_LOG_DEBUG, "seek length(%lli)", m_livePlayer->Length());
-  return m_livePlayer->Length();
+  if (IsServerStreamingLive())
+  {
+    kodi::Log(ADDON_LOG_DEBUG, "seek length(%lli)", m_livePlayer->Length());
+    return m_livePlayer->Length();
+  }
+  return -1;
 }
 
 PVR_ERROR cPVRClientNextPVR::GetSignalStatus(int channelUid, kodi::addon::PVRSignalStatus& signalStatus)
@@ -623,32 +629,39 @@ PVR_ERROR cPVRClientNextPVR::GetSignalStatus(int channelUid, kodi::addon::PVRSig
 
 bool cPVRClientNextPVR::CanPauseStream(void)
 {
-  if (m_nowPlaying == Recording)
+  if (IsServerStreaming())
   {
-    return true;
+    if (m_nowPlaying == Recording)
+      return true;
+    else
+      return m_livePlayer->CanPauseStream();
   }
-  else
-  {
-    bool retval = m_livePlayer->CanPauseStream();
-    return retval;
-  }
+  return false;
 }
 
 void cPVRClientNextPVR::PauseStream(bool bPaused)
 {
-  if (m_nowPlaying == Recording)
-    m_recordingBuffer->PauseStream(bPaused);
-  else
-    m_livePlayer->PauseStream(bPaused);
+  if (IsServerStreaming())
+  {
+    if (m_nowPlaying == Recording)
+      m_recordingBuffer->PauseStream(bPaused);
+    else
+      m_livePlayer->PauseStream(bPaused);
+  }
 }
 
 bool cPVRClientNextPVR::CanSeekStream(void)
 {
-  if (m_nowPlaying == Recording)
-    return true;
-  else
-    return m_livePlayer->CanSeekStream();
+  if (IsServerStreaming())
+  {
+    if (m_nowPlaying == Recording)
+      return true;
+    else
+      return m_livePlayer->CanSeekStream();
+  }
+  return false;
 }
+
 
 /************************************************************/
 /** Record stream handling */
@@ -665,69 +678,119 @@ bool cPVRClientNextPVR::OpenRecordedStream(const kodi::addon::PVRRecording& reco
 
 void cPVRClientNextPVR::CloseRecordedStream(void)
 {
-  m_recordingBuffer->Close();
-  m_recordingBuffer->SetDuration(0);
+  if (IsServerStreamingRecording())
+  {
+    m_recordingBuffer->Close();
+    m_recordingBuffer->SetDuration(0);
+  }
   m_nowPlaying = NotPlaying;
 }
 
 int cPVRClientNextPVR::ReadRecordedStream(unsigned char* pBuffer, unsigned int iBufferSize)
 {
-  iBufferSize = m_recordingBuffer->Read(pBuffer, iBufferSize);
-  return iBufferSize;
+  if (IsServerStreamingRecording())
+  {
+    return m_recordingBuffer->Read(pBuffer, iBufferSize);
+  }
+  return -1;
 }
 
 int64_t cPVRClientNextPVR::SeekRecordedStream(int64_t iPosition, int iWhence)
 {
-  return m_recordingBuffer->Seek(iPosition, iWhence);
+  if (IsServerStreamingRecording())
+  {
+    return m_recordingBuffer->Seek(iPosition, iWhence);
+  }
+  return -1;
 }
 
 int64_t cPVRClientNextPVR::LengthRecordedStream(void)
 {
-  return m_recordingBuffer->Length();
+  if (IsServerStreamingRecording())
+  {
+    return m_recordingBuffer->Length();
+  }
+  return -1;
 }
 
 bool cPVRClientNextPVR::IsTimeshifting()
 {
-  if (m_nowPlaying == Recording)
-    return false;
-  else
+  if (IsServerStreamingLive())
+  {
     return m_livePlayer->IsTimeshifting();
+  }
+  return false;
 }
 
 bool cPVRClientNextPVR::IsRealTimeStream()
 {
-  bool retval;
-  if (m_nowPlaying == Recording)
+  if (IsServerStreaming())
   {
-    retval = m_recordingBuffer->IsRealTimeStream();
+    if (m_nowPlaying == Recording)
+      return m_recordingBuffer->IsRealTimeStream();
+    else
+      return m_livePlayer->IsRealTimeStream();
   }
-  else
-  {
-    retval = m_livePlayer->IsRealTimeStream();
-  }
-  return retval;
+  return false;
 }
 
 PVR_ERROR cPVRClientNextPVR::GetStreamTimes(kodi::addon::PVRStreamTimes& stimes)
 {
-  PVR_ERROR rez;
-  if (m_nowPlaying == Recording)
-    rez = m_recordingBuffer->GetStreamTimes(stimes);
-  else
-    rez = m_livePlayer->GetStreamTimes(stimes);
-  return rez;
+  if (IsServerStreaming())
+  {
+    if (m_nowPlaying == Recording)
+      return m_recordingBuffer->GetStreamTimes(stimes);
+    else
+      return m_livePlayer->GetStreamTimes(stimes);
+  }
+  return PVR_ERROR_UNKNOWN;
 }
 
 PVR_ERROR cPVRClientNextPVR::GetStreamReadChunkSize(int& chunksize)
 {
-  PVR_ERROR rez = PVR_ERROR_NO_ERROR;
-  if (m_nowPlaying == Recording)
-    chunksize = m_settings.m_chunkRecording * 1024;
-  else if (m_nowPlaying == Radio)
-    chunksize = 4096;
-  else
-    rez = m_livePlayer->GetStreamReadChunkSize(chunksize);
-  return rez;
+  if (IsServerStreaming())
+  {
+    if (m_nowPlaying == TV)
+      return m_livePlayer->GetStreamReadChunkSize(chunksize);
+    if (m_nowPlaying == Recording)
+      chunksize = m_settings.m_chunkRecording * 1024;
+    else if (m_nowPlaying == Radio)
+      chunksize = 4096;
+    return PVR_ERROR_NO_ERROR;
+  }
+  return PVR_ERROR_UNKNOWN;
+}
+
+bool cPVRClientNextPVR::IsServerStreaming()
+{
+  if (IsServerStreamingLive(false) || IsServerStreamingRecording(false))
+  {
+    return true;
+  }
+  kodi::Log(ADDON_LOG_ERROR, "Unknown streaming state %d %d %d %d", m_nowPlaying, m_recordingBuffer->GetDuration(), !m_livePlayer);
+  return false;
+}
+
+bool cPVRClientNextPVR::IsServerStreamingLive(bool log)
+{
+  if ((m_nowPlaying == TV || m_nowPlaying == Radio) && m_livePlayer != nullptr)
+  {
+    return true;
+  }
+  if (log)
+    kodi::Log(ADDON_LOG_ERROR, "Unknown live streaming state %d %d %d", m_nowPlaying, m_recordingBuffer->GetDuration(), !m_livePlayer);
+  return false;
+}
+
+bool cPVRClientNextPVR::IsServerStreamingRecording(bool log)
+{
+  if (m_nowPlaying == Recording && m_recordingBuffer->GetDuration() > 0)
+  {
+    return true;
+  }
+  if (log)
+    kodi::Log(ADDON_LOG_ERROR, "Unknown recording streaming state %d %d %d", m_nowPlaying, m_recordingBuffer->GetDuration(), !m_livePlayer);
+  return false;
 }
 
 /*

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -84,6 +84,9 @@ public:
   PVR_ERROR GetStreamTimes(kodi::addon::PVRStreamTimes& times) override;
   PVR_ERROR GetStreamReadChunkSize(int& chunksize) override;
   bool IsRadio() { return m_nowPlaying == Radio; };
+  bool IsServerStreaming();
+  bool IsServerStreamingLive(bool log = true);
+  bool IsServerStreamingRecording(bool log = true);
 
   /* Record stream handling */
   bool OpenRecordedStream(const kodi::addon::PVRRecording& recinfo) override;


### PR DESCRIPTION
PVR Recordings cannot use ADDON_OPEN_CACHED even when finalized.  Kodi core can issue calls against streams that are not open Kodi issue https://github.com/xbmc/xbmc/issues/18368