### PR TITLE
Add cast and crew

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="7.0.1"
+  version="7.0.2"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v7.0.2
+- Add cast and crew from NextPVR 5.0.9
+
 v7.0.1
 - Protect against out media calls from Kodi on closed files
 - Formalize and test manual https support

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,5 +1,6 @@
 v7.0.2
 - Add cast and crew from NextPVR 5.0.9
+- Fix regression in discovery
 
 v7.0.1
 - Protect against out media calls from Kodi on closed files

--- a/pvr.nextpvr/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.nextpvr/resources/language/resource.language.en_gb/strings.po
@@ -313,3 +313,7 @@ msgstr ""
 msgctxt "#30196"
 msgid "Open NextPVR settings"
 msgstr ""
+
+msgctxt "#30197"
+msgid "Show guide cast, director and writer"
+msgstr ""

--- a/pvr.nextpvr/resources/settings.xml
+++ b/pvr.nextpvr/resources/settings.xml
@@ -257,6 +257,16 @@
             </dependency>
           </dependencies>
         </setting>
+        <setting help="" id="castcrew" label="30197" type="boolean">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle"/>
+          <dependencies>
+            <dependency type="visible">
+              <condition operator="is" setting="legacy">false</condition>
+            </dependency>
+          </dependencies>
+        </setting>
         <setting help="30569" id="kodilook" label="30169" type="boolean">
           <level>1</level>
           <default>false</default>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -225,6 +225,8 @@ void Settings::SetVersionSpecificSettings()
     m_showRecordingSize = kodi::GetSettingBoolean("recordingsize", false);
 
     m_transcodedTimeshift = kodi::GetSettingBoolean("ffmpegdirect", false);
+
+    m_castcrew = kodi::GetSettingBoolean("castcrew", false);
   }
   else
   {
@@ -261,6 +263,8 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const kodi::CSet
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_downloadGuideArtwork, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
   else if (settingName == "guideartworkportrait")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_guideArtPortrait, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
+  else if (settingName == "castcrew")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_castcrew, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "recordingsize")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_showRecordingSize, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
   else if (settingName == "flattenrecording")

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -93,6 +93,7 @@ namespace NextPVR
     bool m_sendSidWithMetadata = false;
     bool m_guideArtPortrait = false;
     bool m_genreString = false;
+    bool m_castcrew = false;
 
     //Recordings
     bool m_showRecordingSize = false;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -64,6 +64,8 @@ namespace NextPVR
     {
       m_hostname = host;
       m_port = port;
+      //force to http settings.xml don't exist maybe backend can identify https in the future
+      sprintf(m_urlBase, "http://%.255s:%d", m_hostname.c_str(), m_port);
     };
 
     void ReadFromAddon();


### PR DESCRIPTION
Versions 5.0.9 of the NextPVR backend includes cast and crew.  This adds xml support for it.  Older versions of NextPVR will not have the markup so there are no compatibility concerns.   