### PR TITLE
Standardize backend requests

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="8.0.0"
+  version="8.0.1"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,9 @@
+v8.0.1
+- Rework backend request logic
+- Improved security model on logout/login
+- Added logic to handle fast server restarts
+- When http file is not seekable, force pts start and end to be the same
+
 v8.0.0
 - Update PVR API 7.0.2
 

--- a/src/BackendRequest.h
+++ b/src/BackendRequest.h
@@ -39,10 +39,11 @@ namespace NextPVR
       static Request request;
       return request;
     }
-    int DoRequest(const char* resource, std::string& response);
-    tinyxml2::XMLError DoMethodRequest(const char* resource, tinyxml2::XMLDocument& doc, bool compresssed = true);
+    int DoRequest(std::string resource, std::string& response);
+    bool DoActionRequest(std::string resource);
+    tinyxml2::XMLError DoMethodRequest(std::string resource, tinyxml2::XMLDocument& doc, bool compresssed = true);
     int FileCopy(const char* resource, std::string fileName);
-    tinyxml2::XMLError  GetLastUpdate(const char* resource, time_t& last_update);
+    tinyxml2::XMLError  GetLastUpdate(std::string resource, time_t& last_update);
     bool PingBackend();
     bool OneTimeSetup();
     const char* GetSID() { return m_sid.c_str(); };

--- a/src/EPG.cpp
+++ b/src/EPG.cpp
@@ -21,7 +21,6 @@ using namespace NextPVR::utilities;
 
 PVR_ERROR EPG::GetEPGForChannel(int channelUid, time_t start, time_t end, kodi::addon::PVREPGTagsResultSet& results)
 {
-  std::string response;
   std::pair<bool, bool> channelDetail;
   channelDetail = m_channels.m_channelDetails[channelUid];
   if (channelDetail.first == true)
@@ -35,175 +34,173 @@ PVR_ERROR EPG::GetEPGForChannel(int channelUid, time_t start, time_t end, kodi::
     kodi::Log(ADDON_LOG_DEBUG, "Skipping expired EPG data %d %ld %lld", channelUid, start, end);
     return PVR_ERROR_INVALID_PARAMETERS;
   }
-  std::string request = kodi::tools::StringUtils::Format("/service?method=channel.listings&channel_id=%d&start=%d&end=%d&genre=all", channelUid, static_cast<int>(start), static_cast<int>(end));
+  std::string request = kodi::tools::StringUtils::Format("channel.listings&channel_id=%d&start=%d&end=%d&genre=all", channelUid, static_cast<int>(start), static_cast<int>(end));
   if (m_settings.m_castcrew)
     request.append("&extras=true");
 
-  if (m_request.DoRequest(request.c_str(), response) == HTTP_OK)
+  tinyxml2::XMLDocument doc;
+
+  if (m_request.DoMethodRequest(request, doc) == tinyxml2::XML_SUCCESS)
   {
-    tinyxml2::XMLDocument doc;
-    if (doc.Parse(response.c_str()) == tinyxml2::XML_SUCCESS)
+    tinyxml2::XMLNode* listingsNode = doc.RootElement()->FirstChildElement("listings");
+    for (tinyxml2::XMLNode* pListingNode = listingsNode->FirstChildElement("l"); pListingNode; pListingNode = pListingNode->NextSiblingElement())
     {
-      tinyxml2::XMLNode* listingsNode = doc.RootElement()->FirstChildElement("listings");
-      for (tinyxml2::XMLNode* pListingNode = listingsNode->FirstChildElement("l"); pListingNode; pListingNode = pListingNode->NextSiblingElement())
+      kodi::addon::PVREPGTag broadcast;
+      std::string title;
+      std::string description;
+      std::string subtitle;
+      XMLUtils::GetString(pListingNode, "name", title);
+      XMLUtils::GetString(pListingNode, "description", description);
+
+      if (XMLUtils::GetString(pListingNode, "subtitle", subtitle))
       {
-        kodi::addon::PVREPGTag broadcast;
-        std::string title;
-        std::string description;
-        std::string subtitle;
-        XMLUtils::GetString(pListingNode, "name", title);
-        XMLUtils::GetString(pListingNode, "description", description);
-
-        if (XMLUtils::GetString(pListingNode, "subtitle", subtitle))
+        if (description != subtitle + ":" && kodi::tools::StringUtils::StartsWith(description, subtitle + ": "))
         {
-          if (description != subtitle + ":" && kodi::tools::StringUtils::StartsWith(description, subtitle + ": "))
-          {
-            description = description.substr(subtitle.length() + 2);
-          }
+          description = description.substr(subtitle.length() + 2);
         }
+      }
 
-        broadcast.SetYear(XMLUtils::GetIntValue(pListingNode, "year"));
+      broadcast.SetYear(XMLUtils::GetIntValue(pListingNode, "year"));
 
-        std::string startTime;
-        std::string endTime;
-        XMLUtils::GetString(pListingNode, "start", startTime);
-        startTime.resize(10);
-        XMLUtils::GetString(pListingNode, "end", endTime);
-        endTime.resize(10);
+      std::string startTime;
+      std::string endTime;
+      XMLUtils::GetString(pListingNode, "start", startTime);
+      startTime.resize(10);
+      XMLUtils::GetString(pListingNode, "end", endTime);
+      endTime.resize(10);
 
-        const std::string oidLookup(endTime + ":" + std::to_string(channelUid));
+      const std::string oidLookup(endTime + ":" + std::to_string(channelUid));
 
-        const int epgOid = XMLUtils::GetIntValue(pListingNode, "id");
-        m_timers.m_epgOidLookup[oidLookup] = epgOid;
+      const int epgOid = XMLUtils::GetIntValue(pListingNode, "id");
+      m_timers.m_epgOidLookup[oidLookup] = epgOid;
 
-        broadcast.SetTitle(title);
-        broadcast.SetEpisodeName(subtitle);
-        broadcast.SetUniqueChannelId(channelUid);
-        broadcast.SetStartTime(stol(startTime));
-        broadcast.SetUniqueBroadcastId(stoi(endTime));
-        broadcast.SetEndTime(stol(endTime));
-        broadcast.SetPlot(description);
+      broadcast.SetTitle(title);
+      broadcast.SetEpisodeName(subtitle);
+      broadcast.SetUniqueChannelId(channelUid);
+      broadcast.SetStartTime(stol(startTime));
+      broadcast.SetUniqueBroadcastId(stoi(endTime));
+      broadcast.SetEndTime(stol(endTime));
+      broadcast.SetPlot(description);
 
-        std::string artworkPath;
-        if (m_settings.m_downloadGuideArtwork)
-        {
-          // artwork URL
-          if (m_settings.m_backendVersion < 50000)
-            artworkPath = kodi::tools::StringUtils::Format("%s/service?method=channel.show.artwork&sid=%s&event_id=%d", m_settings.m_urlBase, m_request.GetSID(), epgOid);
-          else
-          {
-            if (m_settings.m_sendSidWithMetadata)
-              artworkPath = kodi::tools::StringUtils::Format("%s/service?method=channel.show.artwork&sid=%s&name=%s", m_settings.m_urlBase, m_request.GetSID(), UriEncode(title).c_str());
-            else
-              artworkPath = kodi::tools::StringUtils::Format("%s/service?method=channel.show.artwork&name=%s", m_settings.m_urlBase, UriEncode(title).c_str());
-            if (m_settings.m_guideArtPortrait)
-              artworkPath += "&prefer=poster";
-          }
-          broadcast.SetIconPath(artworkPath);
-        }
-        std::string sGenre;
-        if (XMLUtils::GetString(pListingNode, "genre", sGenre))
-        {
-          broadcast.SetGenreDescription(sGenre);
-          broadcast.SetGenreType(EPG_GENRE_USE_STRING);
-        }
+      std::string artworkPath;
+      if (m_settings.m_downloadGuideArtwork)
+      {
+        // artwork URL
+        if (m_settings.m_backendVersion < 50000)
+          artworkPath = kodi::tools::StringUtils::Format("%s/service?method=channel.show.artwork&sid=%s&event_id=%d", m_settings.m_urlBase, m_request.GetSID(), epgOid);
         else
         {
-          // genre type
-          broadcast.SetGenreType(XMLUtils::GetIntValue(pListingNode, "genre_type"));
-          broadcast.SetGenreSubType(XMLUtils::GetIntValue(pListingNode, "genre_sub_type"));
-
+          if (m_settings.m_sendSidWithMetadata)
+            artworkPath = kodi::tools::StringUtils::Format("%s/service?method=channel.show.artwork&sid=%s&name=%s", m_settings.m_urlBase, m_request.GetSID(), UriEncode(title).c_str());
+          else
+            artworkPath = kodi::tools::StringUtils::Format("%s/service?method=channel.show.artwork&name=%s", m_settings.m_urlBase, UriEncode(title).c_str());
+          if (m_settings.m_guideArtPortrait)
+            artworkPath += "&prefer=poster";
         }
-        std::string allGenres;
-        if (XMLUtils::GetAdditiveString(pListingNode->FirstChildElement("genres"), "genre", EPG_STRING_TOKEN_SEPARATOR, allGenres, true))
+        broadcast.SetIconPath(artworkPath);
+      }
+      std::string sGenre;
+      if (XMLUtils::GetString(pListingNode, "genre", sGenre))
+      {
+        broadcast.SetGenreDescription(sGenre);
+        broadcast.SetGenreType(EPG_GENRE_USE_STRING);
+      }
+      else
+      {
+        // genre type
+        broadcast.SetGenreType(XMLUtils::GetIntValue(pListingNode, "genre_type"));
+        broadcast.SetGenreSubType(XMLUtils::GetIntValue(pListingNode, "genre_sub_type"));
+
+      }
+      std::string allGenres;
+      if (XMLUtils::GetAdditiveString(pListingNode->FirstChildElement("genres"), "genre", EPG_STRING_TOKEN_SEPARATOR, allGenres, true))
+      {
+        if (allGenres.find(EPG_STRING_TOKEN_SEPARATOR) != std::string::npos)
         {
-          if (allGenres.find(EPG_STRING_TOKEN_SEPARATOR) != std::string::npos)
+          if (broadcast.GetGenreType() != EPG_GENRE_USE_STRING)
           {
-            if (broadcast.GetGenreType() != EPG_GENRE_USE_STRING)
-            {
-              broadcast.SetGenreSubType(EPG_GENRE_USE_STRING);
-            }
-            broadcast.SetGenreDescription(allGenres);
-          }
-          else if (m_settings.m_genreString && broadcast.GetGenreSubType() != EPG_GENRE_USE_STRING)
-          {
-            broadcast.SetGenreDescription(allGenres);
             broadcast.SetGenreSubType(EPG_GENRE_USE_STRING);
           }
-
+          broadcast.SetGenreDescription(allGenres);
         }
-        broadcast.SetSeriesNumber(XMLUtils::GetIntValue(pListingNode, "season", EPG_TAG_INVALID_SERIES_EPISODE));
-        broadcast.SetEpisodeNumber(XMLUtils::GetIntValue(pListingNode, "episode", EPG_TAG_INVALID_SERIES_EPISODE));
-        broadcast.SetEpisodePartNumber(EPG_TAG_INVALID_SERIES_EPISODE);
-
-        std::string original;
-        XMLUtils::GetString(pListingNode, "original", original);
-        broadcast.SetFirstAired(original);
-
-        bool firstrun;
-        if (XMLUtils::GetBoolean(pListingNode, "firstrun", firstrun))
+        else if (m_settings.m_genreString && broadcast.GetGenreSubType() != EPG_GENRE_USE_STRING)
         {
-          if (firstrun)
-          {
-            std::string significance;
-            XMLUtils::GetString(pListingNode, "significance", significance);
-            if (significance == "Live")
-            {
-              broadcast.SetFlags(EPG_TAG_FLAG_IS_LIVE);
-            }
-            else if (significance.find("Premiere") != std::string::npos)
-            {
-              broadcast.SetFlags(EPG_TAG_FLAG_IS_PREMIERE);
-            }
-            else if (significance.find("Finale") != std::string::npos)
-            {
-              broadcast.SetFlags(EPG_TAG_FLAG_IS_FINALE);
-            }
-            else if (m_settings.m_showNew)
-            {
-              broadcast.SetFlags(EPG_TAG_FLAG_IS_NEW);
-            }
-          }
+          broadcast.SetGenreDescription(allGenres);
+          broadcast.SetGenreSubType(EPG_GENRE_USE_STRING);
         }
-        if (m_settings.m_castcrew)
-        {
-          std::string castcrew;
-          XMLUtils::GetString(pListingNode, "cast", castcrew);
-          std::replace(castcrew.begin(), castcrew.end(), ';', ',');
-          kodi::tools::StringUtils::Replace(castcrew, "Actor:", "");
-          kodi::tools::StringUtils::Replace(castcrew, "Host:", "");
-          broadcast.SetCast(castcrew);
 
-          castcrew.clear();
-          XMLUtils::GetString(pListingNode, "crew", castcrew);
-          std::vector<std::string> allcrew = kodi::tools::StringUtils::Split(castcrew, ";", 0);
-          std::string writer;
-          std::string director;
-          for (auto it = allcrew.begin(); it != allcrew.end(); ++it)
-          {
-            std::vector<std::string> onecrew = kodi::tools::StringUtils::Split(*it, ":", 0);
-            if (onecrew.size() == 2)
-            {
-              if (kodi::tools::StringUtils::ContainsKeyword(onecrew[0].c_str(), { "Writer", "Screenwriter" }))
-              {
-                if (!writer.empty())
-                  writer.append(EPG_STRING_TOKEN_SEPARATOR);
-                writer.append(onecrew[1]);
-              }
-              if (onecrew[0] == "Director")
-              {
-                if (!director.empty())
-                  director.append(EPG_STRING_TOKEN_SEPARATOR);
-                director.append(onecrew[1]);
-              }
-            }
-          }
-          broadcast.SetDirector(director);
-          broadcast.SetWriter(writer);
-        }
-        broadcast.SetStarRating(1 + std::rand() % 5);
-        results.Add(broadcast);
       }
+      broadcast.SetSeriesNumber(XMLUtils::GetIntValue(pListingNode, "season", EPG_TAG_INVALID_SERIES_EPISODE));
+      broadcast.SetEpisodeNumber(XMLUtils::GetIntValue(pListingNode, "episode", EPG_TAG_INVALID_SERIES_EPISODE));
+      broadcast.SetEpisodePartNumber(EPG_TAG_INVALID_SERIES_EPISODE);
+
+      std::string original;
+      XMLUtils::GetString(pListingNode, "original", original);
+      broadcast.SetFirstAired(original);
+
+      bool firstrun;
+      if (XMLUtils::GetBoolean(pListingNode, "firstrun", firstrun))
+      {
+        if (firstrun)
+        {
+          std::string significance;
+          XMLUtils::GetString(pListingNode, "significance", significance);
+          if (significance == "Live")
+          {
+            broadcast.SetFlags(EPG_TAG_FLAG_IS_LIVE);
+          }
+          else if (significance.find("Premiere") != std::string::npos)
+          {
+            broadcast.SetFlags(EPG_TAG_FLAG_IS_PREMIERE);
+          }
+          else if (significance.find("Finale") != std::string::npos)
+          {
+            broadcast.SetFlags(EPG_TAG_FLAG_IS_FINALE);
+          }
+          else if (m_settings.m_showNew)
+          {
+            broadcast.SetFlags(EPG_TAG_FLAG_IS_NEW);
+          }
+        }
+      }
+      if (m_settings.m_castcrew)
+      {
+        std::string castcrew;
+        XMLUtils::GetString(pListingNode, "cast", castcrew);
+        std::replace(castcrew.begin(), castcrew.end(), ';', ',');
+        kodi::tools::StringUtils::Replace(castcrew, "Actor:", "");
+        kodi::tools::StringUtils::Replace(castcrew, "Host:", "");
+        broadcast.SetCast(castcrew);
+
+        castcrew.clear();
+        XMLUtils::GetString(pListingNode, "crew", castcrew);
+        std::vector<std::string> allcrew = kodi::tools::StringUtils::Split(castcrew, ";", 0);
+        std::string writer;
+        std::string director;
+        for (auto it = allcrew.begin(); it != allcrew.end(); ++it)
+        {
+          std::vector<std::string> onecrew = kodi::tools::StringUtils::Split(*it, ":", 0);
+          if (onecrew.size() == 2)
+          {
+            if (kodi::tools::StringUtils::ContainsKeyword(onecrew[0].c_str(), { "Writer", "Screenwriter" }))
+            {
+              if (!writer.empty())
+                writer.append(EPG_STRING_TOKEN_SEPARATOR);
+              writer.append(onecrew[1]);
+            }
+            if (onecrew[0] == "Director")
+            {
+              if (!director.empty())
+                director.append(EPG_STRING_TOKEN_SEPARATOR);
+              director.append(onecrew[1]);
+            }
+          }
+        }
+        broadcast.SetDirector(director);
+        broadcast.SetWriter(writer);
+      }
+      broadcast.SetStarRating(1 + std::rand() % 5);
+      results.Add(broadcast);
     }
     return PVR_ERROR_NO_ERROR;
   }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -88,7 +88,7 @@ ADDON_STATUS Settings::ReadBackendSettings()
   std::string settings;
   Request& request = Request::GetInstance();
   tinyxml2::XMLDocument settingsDoc;
-  if (request.DoMethodRequest("/service?method=setting.list", settingsDoc) == tinyxml2::XML_SUCCESS)
+  if (request.DoMethodRequest("setting.list", settingsDoc) == tinyxml2::XML_SUCCESS)
   {
     if (XMLUtils::GetInt(settingsDoc.RootElement(), "NextPVRVersion", m_backendVersion))
     {

--- a/src/buffers/Buffer.h
+++ b/src/buffers/Buffer.h
@@ -26,6 +26,14 @@ using namespace NextPVR;
 
 namespace timeshift {
 
+  enum LeaseStatus
+  {
+    NotActive = -0,
+    Leased = 1,
+    LeaseClosed = 2,
+    LeaseError = 3
+  };
+
   /**
    * The basic type all buffers operate on
    */
@@ -156,7 +164,7 @@ namespace timeshift {
       m_channel_id = channel_id;
     }
 
-    virtual int Lease();
+    virtual enum LeaseStatus Lease();
 
   protected:
 

--- a/src/buffers/ClientTimeshift.cpp
+++ b/src/buffers/ClientTimeshift.cpp
@@ -32,9 +32,8 @@ bool ClientTimeShift::Open(const std::string inputUrl)
 
   if (m_channel_id != 0)
   {
-    std::string timeshift = "/services/service?method=channel.stream.start&channel_id=" + std::to_string(m_channel_id);
-    std::string response;
-    if (m_request.DoRequest(timeshift.c_str(), response) != HTTP_OK)
+    std::string timeshift = "channel.stream.start&channel_id=" + std::to_string(m_channel_id);
+    if (!m_request.DoActionRequest(timeshift))
     {
       return false;
     }
@@ -126,8 +125,7 @@ void ClientTimeShift::Resume()
 
 void ClientTimeShift::StreamStop()
 {
-  std::string response;
-  if (m_request.DoRequest("/services/service?method=channel.stream.stop", response) != HTTP_OK)
+  if (!m_request.DoActionRequest("channel.stream.stop"))
   {
     kodi::Log(ADDON_LOG_ERROR, "%s:%d:", __FUNCTION__, __LINE__);
   }
@@ -180,7 +178,8 @@ bool ClientTimeShift::GetStreamInfo()
     kodi::Log(ADDON_LOG_ERROR, "NextPVR not updating completed rolling file");
     return ( m_stream_length != 0 );
   }
-  if (m_request.DoRequest("/services/service?method=channel.stream.info", response) == HTTP_OK)
+  // this call sends raw xml not a method response
+  if (m_request.DoRequest("/service?method=channel.stream.info", response) == HTTP_OK)
   {
     tinyxml2::XMLDocument doc;
     if (doc.Parse(response.c_str()) == tinyxml2::XML_SUCCESS)

--- a/src/buffers/ClientTimeshift.h
+++ b/src/buffers/ClientTimeshift.h
@@ -74,5 +74,10 @@ namespace timeshift {
     int64_t Seek(int64_t position, int whence) override;
     void StreamStop();
 
+    virtual bool CanSeekStream() const override
+    {
+      return true;
+    }
+
   };
 }

--- a/src/buffers/RecordingBuffer.cpp
+++ b/src/buffers/RecordingBuffer.cpp
@@ -15,8 +15,11 @@ PVR_ERROR RecordingBuffer::GetStreamTimes(kodi::addon::PVRStreamTimes& stimes)
 {
   stimes.SetStartTime(0);
   stimes.SetPTSStart(0);
-  stimes.SetPTSBegin(0);
   stimes.SetPTSEnd(static_cast<int64_t>(Duration()) * STREAM_TIME_BASE);
+  if (CanSeekStream())
+    stimes.SetPTSBegin(0);
+  else
+    stimes.SetPTSBegin(stimes.GetPTSEnd());
   return PVR_ERROR_NO_ERROR;
 }
 

--- a/src/buffers/RecordingBuffer.h
+++ b/src/buffers/RecordingBuffer.h
@@ -45,7 +45,7 @@ namespace timeshift {
 
     virtual bool CanSeekStream() const override
     {
-      return true;
+      return m_inputHandle.GetLength() != 0;
     }
 
     virtual bool IsRealTimeStream() const override

--- a/src/buffers/RollingFile.cpp
+++ b/src/buffers/RollingFile.cpp
@@ -132,7 +132,8 @@ bool RollingFile::GetStreamInfo()
     kodi::Log(ADDON_LOG_ERROR, "NextPVR not updating completed rolling file");
     return ( m_stream_length != 0 );
   }
-  if (m_request.DoRequest("/services/service?method=channel.stream.info", response) == HTTP_OK)
+  // this call returns XML not a response
+  if (m_request.DoRequest("/service?method=channel.stream.info", response) == HTTP_OK)
   {
     tinyxml2::XMLDocument doc;
     if (doc.Parse(response.c_str()) == tinyxml2::XML_SUCCESS)

--- a/src/buffers/TranscodedBuffer.h
+++ b/src/buffers/TranscodedBuffer.h
@@ -31,7 +31,7 @@ namespace timeshift {
 
     int TranscodeStatus();
 
-    int Lease();
+    enum LeaseStatus Lease();
 
     bool CheckStatus();
 

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -207,6 +207,14 @@ ADDON_STATUS cPVRClientNextPVR::Connect(bool sendWOL)
   return status;
 }
 
+
+void cPVRClientNextPVR::ResetConnection()
+{
+  m_nextServerCheck = 0;
+  m_connectionState = PVR_CONNECTION_STATE_DISCONNECTED;
+  m_bConnected = false;
+}
+
 void cPVRClientNextPVR::Disconnect()
 {
   m_request.DoActionRequest("session.logout");
@@ -336,10 +344,10 @@ bool cPVRClientNextPVR::IsUp()
         if (m_connectionState == PVR_CONNECTION_STATE_CONNECTED)
         {
           // allow a one time retry in 60 seconds
-          m_connectionState = PVR_CONNECTION_STATE_DISCONNECTED;
+          m_connectionState = PVR_CONNECTION_STATE_SERVER_UNREACHABLE;
           m_lastRecordingUpdateTime = time(nullptr);
         }
-        else
+        else if (m_connectionState == PVR_CONNECTION_STATE_SERVER_UNREACHABLE)
         {
           SetConnectionState("Lost connection", PVR_CONNECTION_STATE_SERVER_UNREACHABLE);
           m_nextServerCheck = time(nullptr) + 60;
@@ -357,7 +365,7 @@ bool cPVRClientNextPVR::IsUp()
       }
     }
   }
-  else if (m_connectionState == PVR_CONNECTION_STATE_SERVER_UNREACHABLE)
+  else if (m_connectionState == PVR_CONNECTION_STATE_SERVER_UNREACHABLE || m_connectionState == PVR_CONNECTION_STATE_DISCONNECTED)
   {
     if (time(nullptr) > m_nextServerCheck)
     {

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -170,6 +170,7 @@ ADDON_STATUS cPVRClientNextPVR::Connect(bool sendWOL)
         }
         else
         {
+          m_request.DoActionRequest("session.logout");
           SetConnectionState("Version failure", PVR_CONNECTION_STATE_VERSION_MISMATCH, kodi::GetLocalizedString(30050));
           status = ADDON_STATUS_PERMANENT_FAILURE;
         }
@@ -208,6 +209,7 @@ ADDON_STATUS cPVRClientNextPVR::Connect(bool sendWOL)
 
 void cPVRClientNextPVR::Disconnect()
 {
+  m_request.DoActionRequest("session.logout");
   SetConnectionState("Disconnect", PVR_CONNECTION_STATE_DISCONNECTED);
   m_bConnected = false;
 }

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -656,12 +656,9 @@ void cPVRClientNextPVR::PauseStream(bool bPaused)
 
 bool cPVRClientNextPVR::CanSeekStream(void)
 {
-  if (IsServerStreaming())
+  if (IsServerStreamingLive())
   {
-    if (m_nowPlaying == Recording)
-      return true;
-    else
-      return m_livePlayer->CanSeekStream();
+    return m_livePlayer->CanSeekStream();
   }
   return false;
 }

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -51,6 +51,7 @@ public:
   /* Server handling */
   ADDON_STATUS Connect(bool sendWOL = true);
   void Disconnect();
+  void ResetConnection();
   bool IsUp();
   PVR_ERROR OnSystemSleep() override;
   PVR_ERROR OnSystemWake() override;


### PR DESCRIPTION
Move XML validation to single location for consistent error checking on backend requests.   Remove static strings from function calls for readability.  