### PR TITLE
Recording group check

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="8.2.6"
+  version="8.2.7"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v8.2.7
+- Check if recording groups have already been added
+
 v8.2.6
 - Kodi has a limit of 32 EDL breaks in PVR
 

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -412,9 +412,12 @@ PVR_ERROR Timers::GetTimerTypes(std::vector<kodi::addon::PVRTimerType>& types)
 
   /* PVR_Timer.iRecordingGroup values and presentation */
   static std::vector<kodi::addon::PVRTypeIntValue> recordingGroupValues;
-  for (unsigned int i = 0; i < m_settings.m_recordingDirectories.size(); ++i)
+  if (recordingGroupValues.size() == 0)
   {
-    recordingGroupValues.emplace_back(kodi::addon::PVRTypeIntValue(i, m_settings.m_recordingDirectories[i]));
+    for (unsigned int i = 0; i < m_settings.m_recordingDirectories.size(); ++i)
+    {
+      recordingGroupValues.emplace_back(kodi::addon::PVRTypeIntValue(i, m_settings.m_recordingDirectories[i]));
+    }
   }
 
   static const unsigned int TIMER_MANUAL_ATTRIBS


### PR DESCRIPTION
PVRTypeIntValue vectors in GetTimers need to check for empty or size 0 or entries could be re-added when GetTimers () is called more than once.