### PR TITLE
NextPVR API 5.2 changes

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="8.2.7"
+  version="8.2.8"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,7 @@
+v8.2.8
+- Use recording size available in NextPVR API 5.2
+- Create radio groups using API 5.2
+
 v8.2.7
 - Check if recording groups have already been added
 

--- a/src/Channels.h
+++ b/src/Channels.h
@@ -11,6 +11,7 @@
 
 #include "BackendRequest.h"
 #include <kodi/addon-instance/PVR.h>
+#include <set>
 
 namespace NextPVR
 {
@@ -44,6 +45,8 @@ namespace NextPVR
     void DeleteChannelIcons();
     PVR_RECORDING_CHANNEL_TYPE GetChannelType(unsigned int uid);
     std::map<int, std::pair<bool, bool>> m_channelDetails;
+    std::set<std::string> m_tvGroups;
+    std::set<std::string> m_radioGroups;
 
   private:
     Channels() = default;

--- a/src/Recordings.cpp
+++ b/src/Recordings.cpp
@@ -344,7 +344,12 @@ bool Recordings::UpdatePvrRecording(const tinyxml2::XMLNode* pRecordingNode, kod
   std::string recordingFile;
   if (XMLUtils::GetString(pRecordingNode, "file", recordingFile))
   {
-    if (m_settings.m_showRecordingSize)
+    int64_t filesize = 0;
+    if (XMLUtils::GetLong(pRecordingNode, "size", filesize))
+    {
+      tag.SetSizeInBytes(filesize);
+    }
+    else if (m_settings.m_showRecordingSize)
     {
       kodi::tools::StringUtils::Replace(recordingFile, '\\', '/');
       if (kodi::tools::StringUtils::StartsWith(recordingFile, "//"))


### PR DESCRIPTION
NextPVR API 5.2.0 API changes.  Recording size will be forwarded  to core when available.  If the size is not in the XML, use existing logic.   Use radio groups when available.