### PR TITLE
Fix timer default override

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="8.2.8"
+  version="8.2.9"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v8.2.9
+- Fix timer default override
+
 v8.2.8
 - Use recording size available in NextPVR API 5.2
 - Create radio groups using API 5.2

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -659,7 +659,7 @@ PVR_ERROR Timers::AddTimer(const kodi::addon::PVRTimer& timer)
 
   int marginStart = timer.GetMarginStart();
   int marginEnd = timer.GetMarginEnd();
-  if (m_settings.m_ignorePadding && timer.GetClientIndex() == PVR_TIMER_NO_CLIENT_INDEX && marginStart == 0 && marginStart == 0)
+  if (m_settings.m_ignorePadding && timer.GetClientIndex() == PVR_TIMER_NO_CLIENT_INDEX && marginStart == 0 && marginEnd == 0)
   {
     marginStart = m_settings.m_defaultPrePadding;
     marginEnd = m_settings.m_defaultPostPadding;


### PR DESCRIPTION
Feature was supposed to override only when padding margin start/end were zero.    Reported on forum https://forum.kodi.tv/showthread.php?tid=364475