### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="20.0.0"
+  version="20.1.0"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,8 @@
+v20.1.0
+- Kodi API to 8.0.0
+  - Add supports recordings delete capability
+  - Enforce EDL limits
+
 v20.0.0
 - Translations updates from Weblate
   - be_by, ko_kr, ru_ru

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -963,6 +963,7 @@ PVR_ERROR cPVRClientNextPVR::GetCapabilities(kodi::addon::PVRCapabilities& capab
 
   capabilities.SetSupportsEPG(true);
   capabilities.SetSupportsRecordings(true);
+  capabilities.SetSupportsRecordingsDelete(true);
   capabilities.SetSupportsRecordingsUndelete(false);
   capabilities.SetSupportsRecordingSize(m_settings.m_showRecordingSize);
   capabilities.SetSupportsTimers(true);


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Add supports recordings delete capability
  - Enforce EDL limits

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395