### PR TITLE
In-progress recording fix

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="19.0.1"
+  version="19.0.2"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v19.0.2
+- Fix for Kodi marking in-progress recordings as watched
+
 v19.0.1
 - Don't try and reconnect server after sleep announced
 - Adjust timeshift when v4 setting logic get confused


### PR DESCRIPTION
Kodi will mark an in-progress recording as watched if the user exits close to real time before it finishes.  Use clock time as the watched position in this case.