### PR TITLE
In progress recording fix

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="20.1.2"
+  version="20.1.3"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v20.1.3
+- Fix for Kodi marking in-progress recordings as watched
+
 v20.1.2
 - Remove obsolete V4 settings from settings.xml
 - Load and save only V5 settings

--- a/src/Recordings.cpp
+++ b/src/Recordings.cpp
@@ -543,7 +543,7 @@ PVR_ERROR Recordings::SetRecordingPlayCount(const kodi::addon::PVRRecording& rec
 PVR_ERROR Recordings::SetRecordingLastPlayedPosition(const kodi::addon::PVRRecording& recording, int lastplayedposition)
 {
 
-  int originalPosition = lastplayedposition;
+  bool isWatched = true;
   int current = m_playCount[std::stoi(recording.GetRecordingId())];
   if (recording.GetPlayCount() > current && lastplayedposition == 0)
   {
@@ -558,7 +558,15 @@ PVR_ERROR Recordings::SetRecordingLastPlayedPosition(const kodi::addon::PVRRecor
     time_t timerUpdate = m_timers.m_lastTimerUpdateTime;
     if (lastplayedposition == -1)
     {
-      lastplayedposition = recording.GetDuration();
+      if (recording.GetRecordingTime() + recording.GetDuration() > time(nullptr)) 
+      {
+        lastplayedposition = time(nullptr) - recording.GetRecordingTime() - 5;
+        isWatched = false;      
+      }
+      else
+      {
+        lastplayedposition = recording.GetDuration();
+      }
     }
     const std::string request = kodi::tools::StringUtils::Format("recording.watched.set&recording_id=%s&position=%d", recording.GetRecordingId().c_str(), lastplayedposition);
     tinyxml2::XMLDocument doc;
@@ -576,6 +584,9 @@ PVR_ERROR Recordings::SetRecordingLastPlayedPosition(const kodi::addon::PVRRecor
         {
           // only change is watched point so skip it
           m_lastPlayed[std::stoi(recording.GetRecordingId())] = lastplayedposition;
+          // reload recording list so Kodi can get new duration
+          if (!isWatched)
+            g_pvrclient->TriggerRecordingUpdate();
           g_pvrclient->m_lastRecordingUpdateTime = lastUpdate;
         }
       }


### PR DESCRIPTION
Kodi will mark an in-progress recording as watched if the user is watching in close to real time. Set clock time as the watched position.