### PR TITLE
Use cached group counts

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="20.2.0"
+  version="20.2.1"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v20.2.1
+- Used cached group counts for GetChannelGroupsAmount()
+
 v20.2.0
 - Translation updates by Weblate
 - Kodi main API update to version 2.0.0

--- a/src/Channels.cpp
+++ b/src/Channels.cpp
@@ -175,18 +175,8 @@ PVR_ERROR Channels::GetChannels(bool radio, kodi::addon::PVRChannelsResultSet& r
 
 PVR_ERROR Channels::GetChannelGroupsAmount(int& amount)
 {
-  int groups = 0;
-  tinyxml2::XMLDocument doc;
-  if (m_request.DoMethodRequest("channel.groups", doc) == tinyxml2::XML_SUCCESS)
-  {
-    tinyxml2::XMLNode* groupsNode = doc.RootElement()->FirstChildElement("groups");
-    tinyxml2::XMLNode* pGroupNode;
-    for( pGroupNode = groupsNode->FirstChildElement("group"); pGroupNode; pGroupNode=pGroupNode->NextSiblingElement())
-    {
-      groups++;
-    }
-  }
-  amount = groups;
+  // this could be different from the number of backend groups if radio and TV are mixed or if groups are empty
+  amount = m_radioGroups.size() + m_tvGroups.size();
   return PVR_ERROR_NO_ERROR;
 }
 


### PR DESCRIPTION
Nexus can poll group counts frequently.  Use the internal counts rather then unnecessarily calling the backend.