### PR TITLE
Send groups in NextPVR order

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="20.2.1"
+  version="20.2.2"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v20.2.2
+- Send channel groups in NextPVR order
+
 v20.2.1
 - Used cached group counts for GetChannelGroupsAmount()
 

--- a/src/Channels.h
+++ b/src/Channels.h
@@ -10,7 +10,7 @@
 
 #include "BackendRequest.h"
 #include <kodi/addon-instance/PVR.h>
-#include <set>
+#include <unordered_set>
 
 namespace NextPVR
 {
@@ -44,8 +44,8 @@ namespace NextPVR
     void DeleteChannelIcons();
     PVR_RECORDING_CHANNEL_TYPE GetChannelType(unsigned int uid);
     std::map<int, std::pair<bool, bool>> m_channelDetails;
-    std::set<std::string> m_tvGroups;
-    std::set<std::string> m_radioGroups;
+    std::unordered_set<std::string> m_tvGroups;
+    std::unordered_set<std::string> m_radioGroups;
 
   private:
     Channels() = default;


### PR DESCRIPTION
Respect channel group delivery sort order from NextPVR.  Can be creation date or  name.  There is no priority in NextPVR but after this change users can create groups in the order they want them displayed in Kodi.