### PR TITLE
Remove server-based season episode option.

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="20.2.2"
+  version="20.2.3"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v20.2.3
+- Remove backend forced season/episode support
+
 v20.2.2
 - Send channel groups in NextPVR order
 

--- a/pvr.nextpvr/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.nextpvr/resources/language/resource.language.en_gb/strings.po
@@ -190,14 +190,6 @@ msgctxt "#30168"
 msgid "Recording chunk size"
 msgstr ""
 
-msgctxt "#30169"
-msgid "Kodi skin styled recordings"
-msgstr ""
-
-msgctxt "#30569"
-msgid "Separate title, season and episode for skin - season and episode numbers will not be shown in lists"
-msgstr ""
-
 msgctxt "#30170"
 msgid "Refresh cache for channel icons"
 msgstr ""

--- a/pvr.nextpvr/resources/settings.xml
+++ b/pvr.nextpvr/resources/settings.xml
@@ -210,20 +210,10 @@
           <default>false</default>
           <control type="toggle"/>
         </setting>
-        <setting help="30569" id="kodilook" label="30169" type="boolean">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle"/>
-        </setting>
-        <setting help="30680" id="flattenrecording" label="30180" type="boolean"  parent="kodilook">
+        <setting help="30680" id="flattenrecording" label="30180" type="boolean">
           <level>2</level>
           <default>false</default>
           <control type="toggle"/>
-          <dependencies>
-            <dependency type="visible">
-              <condition operator="is" setting="kodilook">true</condition>
-            </dependency>
-          </dependencies>
         </setting>
         <setting help="30699" id="ignorepadding" label="30199" type="boolean">
           <level>2</level>
@@ -270,6 +260,11 @@
     <category help="" id="deadsettings" label="">
       <!-- Avoid Kodi creating debug log messages for obsolete user settings -->>
       <group id="13">
+        <setting help="" id="kodilook" label="" type="boolean">
+          <level>4</level>
+          <default>false</default>
+          <control type="toggle"/>
+        </setting>
         <setting help="" id="usetimeshift" label="" type="boolean" option="hidden">
           <level>4</level>
           <default>false</default>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -60,8 +60,6 @@ void Settings::ReadFromAddon()
 
   m_separateSeasons = kodi::addon::GetSettingBoolean("separateseasons", false);
 
-  m_kodiLook = kodi::addon::GetSettingBoolean("kodilook", false);
-
   m_prebuffer5 = kodi::addon::GetSettingInt("prebuffer5", 0);
 
   m_liveChunkSize = kodi::addon::GetSettingInt("chunklivetv", 64);
@@ -230,13 +228,11 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const kodi::addo
   else if (settingName == "diskspace")
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_diskSpace, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "flattenrecording")
-    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_flattenRecording, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_flattenRecording, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "ignorepadding")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_ignorePadding, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "separateseasons")
-    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_separateSeasons, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
-  else if (settingName == "kodilook")
-    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_kodiLook, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_separateSeasons, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "genrestring")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_genreString, ADDON_STATUS_NEED_SETTINGS, ADDON_STATUS_OK);
   else if (settingName == "host_mac")

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -99,7 +99,6 @@ namespace NextPVR
     std::string m_diskSpace = "No";
     bool m_flattenRecording = false;
     bool m_separateSeasons = true;
-    bool m_kodiLook = false;
     int m_chunkRecording = 32;
 
     //Timers


### PR DESCRIPTION
Kodi Nexus now fully supports season and episodes sorting and display.  Removes now redundant server side option that most users have been using.