### PR TITLE
Startup delay backport

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="19.0.3"
+  version="19.0.4"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,5 @@
+v19.0.4
+- Backport start fast poll change from PR 214
 v19.0.3
 - Translations updates from Weblate
 	- da_dk, es_mx

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -73,6 +73,14 @@ std::string UriEncode(const std::string sSrc)
   return sResult;
 }
 
+#define SLOW_CONNECT_POLL 60
+#define FAST_CONNECT_POLL 5
+
+/* needs extra time to start of zeroconf tuner connection fails
+* this timeout is 60 seconds so wait a short time afterwards */
+
+#define FAST_SLOW_POLL_TRANSITION 65
+
 /************************************************************/
 /** Class interface */
 
@@ -127,6 +135,8 @@ ADDON_STATUS cPVRClientNextPVR::Connect(bool sendWOL)
     SendWakeOnLan();
   m_request.ClearSID();
   tinyxml2::XMLDocument doc;
+  if (m_firstSessionInitiate == 0)
+    m_firstSessionInitiate = time(nullptr);
   if (m_request.DoMethodRequest("session.initiate&ver=1.0&device=xbmc", doc) == tinyxml2::XML_SUCCESS)
   {
     std::string salt;
@@ -194,7 +204,10 @@ ADDON_STATUS cPVRClientNextPVR::Connect(bool sendWOL)
         SetConnectionState("Connnecting", PVR_CONNECTION_STATE_CONNECTING);
       }
       m_connectionState = PVR_CONNECTION_STATE_SERVER_UNREACHABLE;
-      m_nextServerCheck = time(nullptr) + 60;
+      if (time(nullptr) > m_firstSessionInitiate + FAST_SLOW_POLL_TRANSITION)
+        m_nextServerCheck = time(nullptr) + SLOW_CONNECT_POLL;
+      else
+        m_nextServerCheck = time(nullptr) + FAST_CONNECT_POLL;
     }
     else
     {
@@ -362,7 +375,7 @@ bool cPVRClientNextPVR::IsUp()
         else if (m_connectionState == PVR_CONNECTION_STATE_SERVER_UNREACHABLE)
         {
           SetConnectionState("Lost connection", PVR_CONNECTION_STATE_SERVER_UNREACHABLE);
-          m_nextServerCheck = time(nullptr) + 60;
+          m_nextServerCheck = time(nullptr) + SLOW_CONNECT_POLL;
           m_bConnected = false;
         }
       }
@@ -385,7 +398,7 @@ bool cPVRClientNextPVR::IsUp()
   {
     if (time(nullptr) > m_nextServerCheck)
     {
-      m_nextServerCheck = time(nullptr) + 60;
+      m_nextServerCheck = time(nullptr) + SLOW_CONNECT_POLL;
       Connect(false);
       if (m_bConnected)
       {
@@ -418,7 +431,7 @@ PVR_ERROR cPVRClientNextPVR::OnSystemWake()
 {
   kodi::Log(ADDON_LOG_DEBUG, "NextPVR wake");
   // allow time for core to reset
-  m_lastRecordingUpdateTime = time(nullptr) + 60;
+  m_lastRecordingUpdateTime = time(nullptr) + SLOW_CONNECT_POLL;
   m_nextServerCheck = 0;
   // don't trigger updates core does it
   SetConnectionState("Reconnect", PVR_CONNECTION_STATE_UNKNOWN);

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -151,14 +151,12 @@ private:
   std::thread m_thread;
   bool m_supportsLiveTimeshift;
 
-
   time_t m_tsbStartTime;
   int m_timeShiftBufferSeconds;
   timeshift::Buffer* m_timeshiftBuffer;
   timeshift::Buffer* m_livePlayer;
   timeshift::Buffer* m_realTimeBuffer;
   timeshift::RecordingBuffer* m_recordingBuffer;
-
 
   //Matrix changes
   NextPVR::Settings& m_settings = NextPVR::Settings::GetInstance();
@@ -167,5 +165,6 @@ private:
   void SetConnectionState(std::string message, PVR_CONNECTION_STATE state, std::string displayMessage = "");
   PVR_CONNECTION_STATE m_connectionState = PVR_CONNECTION_STATE_UNKNOWN;
   PVR_CONNECTION_STATE m_coreState = PVR_CONNECTION_STATE_UNKNOWN;
+  time_t m_firstSessionInitiate = 0;
 
 };


### PR DESCRIPTION
Backport change from PR 214 allowing a faster poll for the NextPVR backend on startup.