### PR TITLE
Adjust channel group logic

### DIFF
--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,5 +1,6 @@
 v20.3.1
 - Implement advanced recording title search
+- Adjust for Nexus change in Channel Group order
 
 v20.3.0
 - Kodi inputstream API update to version 3.2.0


### PR DESCRIPTION
Nexus changed logic and channel groups are now loaded before channels.  Group logic in  pvr.nextpvr requires the channels to be loaded first to classify Radio and TV groups.  The calling order of these calls was not documented and this will be safer but it will also mean backend channel lists will be called 2 additional times.    GetChannelGroupAmount() is still assumed after the group loads to save an additional call.

This change could impact load time of very large IPTV lists and users might need to be advised to disable Radio when they they are only using TV.