### PR TITLE
Connection state change

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -5,7 +5,7 @@
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@
-    <import addon="inputstream.ffmpegdirect" minversion="21.0.0"/>
+    <import addon="inputstream.ffmpegdirect" minversion="1.15.0" optional="true"/>
   </requires>
   <extension
     point="kodi.pvrclient"

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,6 @@
+v21.0.0
+- Connection change, start in connnecting state, defer unreachable state.
+
 v20.4.0
 - Add support for multiple NextPVR instances
 - Adjust for Nexus change in Channel Group order


### PR DESCRIPTION
Change initial connection to connecting state and defer going into unreachable state to avoid event disruption on startup.