### PR TITLE
Wakeup improvements

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="21.0.0"
+  version="21.0.1"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,8 @@
+v21.0.1
+- Return error if channel calls are made when not connected
+- Fast poll for servers after returning from sleep
+- Changes to backend art delivery, request fanart if possible
+
 v21.0.0
 - Connection change, start in connnecting state, defer unreachable state.
 

--- a/src/BackendRequest.cpp
+++ b/src/BackendRequest.cpp
@@ -66,7 +66,7 @@ namespace NextPVR
     // return is same on timeout or http return ie 404, 500.
     tinyxml2::XMLError retError = tinyxml2::XML_ERROR_FILE_NOT_FOUND;
     std::unique_lock<std::mutex> lock(m_mutexRequest);
-    // build request string, adding SID if requred
+    // build request string, adding SID if required
     std::string URL;
 
     if (IsActiveSID())
@@ -74,7 +74,10 @@ namespace NextPVR
     else if (kodi::tools::StringUtils::StartsWith(resource, "session"))
       URL = kodi::tools::StringUtils::Format("%s/service?method=%s", m_settings->m_urlBase, resource.c_str());
     else
+    {
+      kodi::Log(ADDON_LOG_ERROR, "%s called before session.login", resource.c_str());
       return tinyxml2::XML_ERROR_FILE_COULD_NOT_BE_OPENED;
+    }
 
     if (!compressed)
       URL += "|Accept-Encoding=identity";

--- a/src/Channels.cpp
+++ b/src/Channels.cpp
@@ -88,7 +88,7 @@ PVR_ERROR Channels::GetChannels(bool radio, kodi::addon::PVRChannelsResultSet& r
 {
   if (radio && !m_settings->m_showRadio)
     return PVR_ERROR_NO_ERROR;
-
+  PVR_ERROR returnValue = PVR_ERROR_NO_ERROR;
   std::string stream;
   std::map<int, std::pair<bool, bool>>::iterator  itr = m_channelDetails.begin();
   while (itr != m_channelDetails.end())
@@ -160,8 +160,13 @@ PVR_ERROR Channels::GetChannels(bool radio, kodi::addon::PVRChannelsResultSet& r
       results.Add(tag);
     }
   }
-  return PVR_ERROR_NO_ERROR;
+  else
+  {
+    returnValue = PVR_ERROR_SERVER_ERROR;
+  }
+  return returnValue;
 }
+
 
 /************************************************************/
 /** Channel group handling **/
@@ -187,6 +192,7 @@ PVR_ERROR Channels::GetChannelGroups(bool radio, kodi::addon::PVRChannelGroupsRe
   if (radio && !m_settings->m_showRadio)
     return PVR_ERROR_NO_ERROR;
 
+  PVR_ERROR returnValue = PVR_ERROR_NO_ERROR;
   int priority = 1;
 
   std::unordered_set<std::string>& selectedGroups = radio ? m_radioGroups : m_tvGroups;
@@ -235,6 +241,10 @@ PVR_ERROR Channels::GetChannelGroups(bool radio, kodi::addon::PVRChannelGroupsRe
       }
     }
   }
+  else
+  {
+    return PVR_ERROR_SERVER_ERROR;
+  }
 
   // Many users won't have radio groups
   if (selectedGroups.size() == 0)
@@ -265,14 +275,15 @@ PVR_ERROR Channels::GetChannelGroups(bool radio, kodi::addon::PVRChannelGroupsRe
   else
   {
     kodi::Log(ADDON_LOG_DEBUG, "No Channel Group");
+    returnValue =  PVR_ERROR_SERVER_ERROR;
   }
-
-  return PVR_ERROR_NO_ERROR;
+  return returnValue;
 }
 
 PVR_ERROR Channels::GetChannelGroupMembers(const kodi::addon::PVRChannelGroup& group, kodi::addon::PVRChannelGroupMembersResultSet& results)
 {
   std::string request;
+  PVR_ERROR returnValue = PVR_ERROR_SERVER_ERROR;
 
   if (group.GetGroupName() == GetAllChannelsGroupName(group.GetIsRadio()))
   {
@@ -304,7 +315,11 @@ PVR_ERROR Channels::GetChannelGroupMembers(const kodi::addon::PVRChannelGroup& g
       }
     }
   }
-  return PVR_ERROR_NO_ERROR;
+  else
+  {
+    returnValue = PVR_ERROR_SERVER_ERROR;
+  }
+  return returnValue;
 }
 
 const std::string Channels::GetAllChannelsGroupName(bool radio)

--- a/src/EPG.cpp
+++ b/src/EPG.cpp
@@ -94,8 +94,11 @@ PVR_ERROR EPG::GetEPGForChannel(int channelUid, time_t start, time_t end, kodi::
           artworkPath = kodi::tools::StringUtils::Format("%s/service?method=channel.show.artwork&sid=%s&name=%s", m_settings->m_urlBase, m_request.GetSID(), UriEncode(title).c_str());
         else
           artworkPath = kodi::tools::StringUtils::Format("%s/service?method=channel.show.artwork&name=%s", m_settings->m_urlBase, UriEncode(title).c_str());
+
         if (m_settings->m_guideArtPortrait)
           artworkPath += "&prefer=poster";
+        else
+          artworkPath += "&prefer=landscape";
         broadcast.SetIconPath(artworkPath);
       }
       std::string sGenre;

--- a/src/Recordings.cpp
+++ b/src/Recordings.cpp
@@ -443,9 +443,8 @@ bool Recordings::UpdatePvrRecording(const tinyxml2::XMLNode* pRecordingNode, kod
       artworkPath = kodi::tools::StringUtils::Format("%s/service?method=channel.show.artwork&sid=%s&name=%s", m_settings->m_urlBase, m_request.GetSID(), name.c_str());
     else
       artworkPath = kodi::tools::StringUtils::Format("%s/service?method=channel.show.artwork&name=%s", m_settings->m_urlBase, name.c_str());
-    tag.SetFanartPath(artworkPath);
-    artworkPath += "&prefer=poster";
-    tag.SetThumbnailPath(artworkPath);
+    tag.SetFanartPath(artworkPath + "&prefer=fanart");
+    tag.SetThumbnailPath(artworkPath + "&prefer=poster");
   }
   if (XMLUtils::GetAdditiveString(pRecordingNode->FirstChildElement("genres"), "genre", EPG_STRING_TOKEN_SEPARATOR, buffer, true))
   {

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -895,6 +895,12 @@ PVR_ERROR cPVRClientNextPVR::GetEPGForChannel(int channelUid, time_t start, time
 /** PVR Channel Functions                 **/
 PVR_ERROR cPVRClientNextPVR::GetChannelsAmount(int& amount)
 {
+  if (m_connectionState != PVR_CONNECTION_STATE_CONNECTED)
+  {
+    kodi::Log(ADDON_LOG_ERROR, "GetChannelsAmount called while disconnected");
+    return PVR_ERROR_SERVER_ERROR;
+  }
+
   amount = m_channels.GetNumChannels();
   return PVR_ERROR_NO_ERROR;
 }
@@ -910,6 +916,12 @@ PVR_ERROR cPVRClientNextPVR::GetChannels(bool radio, kodi::addon::PVRChannelsRes
 
 PVR_ERROR cPVRClientNextPVR::GetChannelGroupsAmount(int& amount)
 {
+  if (m_connectionState != PVR_CONNECTION_STATE_CONNECTED)
+  {
+    kodi::Log(ADDON_LOG_ERROR, "GetChannelGroupsAmount called while disconnected");
+    return PVR_ERROR_SERVER_ERROR;
+  }
+
   m_channels.GetChannelGroupsAmount(amount);
   return PVR_ERROR_NO_ERROR;
 }


### PR DESCRIPTION
After resuming from sleep Kodi will request channel update and if disconnected pvr.nextpvr was not returning an error as required by the API.

Also change to fast poll for servers after wake to account for nic startup and local server startup