### PR TITLE
Port of PR #241

### DIFF
--- a/pvr.nextpvr/addon.xml.in
+++ b/pvr.nextpvr/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="21.0.1"
+  version="21.0.2"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>@ADDON_DEPENDS@

--- a/pvr.nextpvr/changelog.txt
+++ b/pvr.nextpvr/changelog.txt
@@ -1,3 +1,7 @@
+v21.0.2
+ - Add missing return ChannelGroup return code
+ - Stop caching LiveStreams.xml
+
 v21.0.1
 - Return error if channel calls are made when not connected
 - Fast poll for servers after returning from sleep

--- a/src/BackendRequest.cpp
+++ b/src/BackendRequest.cpp
@@ -21,9 +21,11 @@ namespace NextPVR
   int Request::DoRequest(std::string resource, std::string& response)
   {
     auto start = std::chrono::steady_clock::now();
+    char separator = resource.find("?") == std::string::npos ? '?' : '&';
     std::unique_lock<std::mutex> lock(m_mutexRequest);
-    // build request string, adding SID if requred
-    const std::string URL = kodi::tools::StringUtils::Format("%s%s&sid=%s", m_settings->m_urlBase, resource.c_str(), GetSID());
+    // build request string, adding SID
+    const std::string URL = kodi::tools::StringUtils::Format("%s%s%csid=%s", m_settings->m_urlBase,
+      resource.c_str(), separator, GetSID());
 
     // ask XBMC to read the URL for us
     int resultCode = HTTP_NOTFOUND;
@@ -38,7 +40,7 @@ namespace NextPVR
       }
       stream.Close();
       resultCode = HTTP_OK;
-      if ((response.empty() || strstr(response.c_str(), "<rsp stat=\"ok\">") == nullptr) && resource.find("channel.stream.info") == std::string::npos)
+      if (response.empty())
       {
         kodi::Log(ADDON_LOG_ERROR, "DoRequest failed, response=%s", response.c_str());
         resultCode = HTTP_BADREQUEST;

--- a/src/Channels.cpp
+++ b/src/Channels.cpp
@@ -314,6 +314,7 @@ PVR_ERROR Channels::GetChannelGroupMembers(const kodi::addon::PVRChannelGroup& g
         results.Add(tag);
       }
     }
+    returnValue = PVR_ERROR_NO_ERROR;
   }
   else
   {
@@ -350,14 +351,13 @@ bool Channels::IsChannelAPlugin(int uid)
 /************************************************************/
 void Channels::LoadLiveStreams()
 {
+  std::string response;
   const std::string URL = "/public/LiveStreams.xml";
   m_liveStreams.clear();
-  if (m_request.FileCopy(URL.c_str(), m_settings->m_instanceDirectory + "LiveStreams.xml") == HTTP_OK)
+  if (m_request.DoRequest(URL, response) == HTTP_OK)
   {
     tinyxml2::XMLDocument doc;
-    std::string liveStreams = kodi::vfs::TranslateSpecialProtocol(m_settings->m_instanceDirectory + "LiveStreams.xml");
-    kodi::Log(ADDON_LOG_DEBUG, "Loading LiveStreams.xml %s", liveStreams.c_str());
-    if (doc.LoadFile(liveStreams.c_str()) == tinyxml2::XML_SUCCESS)
+    if (doc.Parse(response.c_str()) == tinyxml2::XML_SUCCESS)
     {
       tinyxml2::XMLNode* streamsNode = doc.FirstChildElement("streams");
       if (streamsNode)
@@ -381,6 +381,10 @@ void Channels::LoadLiveStreams()
           }
         }
       }
+    }
+    else
+    {
+      kodi::Log(ADDON_LOG_ERROR, "LiveStreams invalid xml");
     }
   }
 }


### PR DESCRIPTION
Missing return code was creating incorrect Kodi log messages.  Currently Kodi core  ignores the client error when returned.   Read LiveStreams.xml to string buffer instead of file.  Remove unused legacy DoRequest  check.
