### PR TITLE
Trigger channel list updates

### DIFF
--- a/src/Channels.h
+++ b/src/Channels.h
@@ -14,6 +14,7 @@
 
 namespace NextPVR
 {
+  typedef struct { time_t updateTime; size_t size; } CacheHeader;
 
   class ATTR_DLL_LOCAL Channels
   {
@@ -25,9 +26,10 @@ namespace NextPVR
     /* Channel handling */
     int GetNumChannels();
 
-    bool CacheAllChannels(time_t updateTime);
+    bool ChannelCacheChanged(time_t updateTime);
 
     PVR_ERROR GetChannels(bool radio, kodi::addon::PVRChannelsResultSet& results);
+    bool ResetChannelCache(time_t updateTime);
     /* Channel group handling */
     PVR_ERROR GetChannelGroupsAmount(int& amount);
     PVR_ERROR GetChannelGroups(bool radio, kodi::addon::PVRChannelGroupsResultSet& results);
@@ -43,6 +45,7 @@ namespace NextPVR
     std::map<int, std::pair<bool, bool>> m_channelDetails;
     std::unordered_set<std::string> m_tvGroups;
     std::unordered_set<std::string> m_radioGroups;
+    mutable std::recursive_mutex m_channelMutex;
 
   private:
     Channels() = default;
@@ -53,6 +56,11 @@ namespace NextPVR
     std::string GetChannelIcon(int channelID);
     const std::shared_ptr<InstanceSettings> m_settings;
     Request& m_request;
-    tinyxml2::XMLError ReadCachedChannelList(tinyxml2::XMLDocument& doc);
+    tinyxml2::XMLError GetChannelList(tinyxml2::XMLDocument& doc);
+    time_t ReadChannelListCache(std::string& response);
+    bool ReloadChannelListCache(std::string& response, time_t updateTime);
+    bool LoadChannelDetails();
+    std::string m_checksumChannelList;
+    const std::string m_channelCacheFile;
   };
 } // namespace NextPVR

--- a/src/EPG.cpp
+++ b/src/EPG.cpp
@@ -31,7 +31,10 @@ EPG::EPG(const std::shared_ptr<InstanceSettings>& settings, Request& request, Re
 PVR_ERROR EPG::GetEPGForChannel(int channelUid, time_t start, time_t end, kodi::addon::PVREPGTagsResultSet& results)
 {
   std::pair<bool, bool> channelDetail;
-  channelDetail = m_channels.m_channelDetails[channelUid];
+  {
+    std::lock_guard<std::recursive_mutex> lock(m_channels.m_channelMutex);
+    channelDetail = m_channels.m_channelDetails[channelUid];
+  }
   if (channelDetail.first == true)
   {
     kodi::Log(ADDON_LOG_DEBUG, "Skipping %d", channelUid);

--- a/src/Recordings.cpp
+++ b/src/Recordings.cpp
@@ -22,7 +22,7 @@ using namespace NextPVR::utilities;
 /************************************************************/
 /** Record handling **/
 
-Recordings::Recordings(const std::shared_ptr<InstanceSettings>& settings, Request& request, Timers& timers, Channels& channels, 
+Recordings::Recordings(const std::shared_ptr<InstanceSettings>& settings, Request& request, Timers& timers, Channels& channels,
     GenreMapper& genreMapper, cPVRClientNextPVR& pvrclient) :
   m_settings(settings),
   m_request(request),
@@ -521,7 +521,7 @@ bool Recordings::ParseNextPVRSubtitle(const tinyxml2::XMLNode *pRecordingNode, k
       }
     }
     const std::string plot = tag.GetPlot();
-    if (tag.GetEpisodeNumber() == PVR_RECORDING_INVALID_SERIES_EPISODE && !plot.empty());
+    if (tag.GetEpisodeNumber() == PVR_RECORDING_INVALID_SERIES_EPISODE && !plot.empty())
     {
       static std::regex base_regex("^.*\\([eE][pP](\\d+)(?:/?(\\d+))?\\)");
       std::smatch base_match;

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -78,6 +78,7 @@ PVR_ERROR Timers::GetTimers(kodi::addon::PVRTimersResultSet& results)
   int timerCount = 0;
   // first add the recurring recordings
   tinyxml2::XMLDocument doc;
+  std::lock_guard<std::recursive_mutex> lock(m_channels.m_channelMutex);
   if (m_request.DoMethodRequest("recording.recurring.list", doc) == tinyxml2::XML_SUCCESS)
   {
     tinyxml2::XMLNode* recurringsNode = doc.RootElement()->FirstChildElement("recurrings");

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -312,7 +312,8 @@ void cPVRClientNextPVR::ConfigurePostConnectionOptions()
   if (m_lastEPGUpdateTime == 0)
     m_request.GetLastUpdate("system.epg.summary", m_lastEPGUpdateTime);
 
-  m_channels.CacheAllChannels(m_lastEPGUpdateTime);
+  // cache channel list on startup
+  m_channels.ResetChannelCache(m_lastEPGUpdateTime);
 }
 
 /* IsUp()
@@ -342,6 +343,14 @@ bool cPVRClientNextPVR::IsUp()
           {
             if (lastUpdate > m_lastEPGUpdateTime)
             {
+              // if channel list changed trigger channel updates
+              if (m_channels.ResetChannelCache(lastUpdate))
+              {
+                kodi::Log(ADDON_LOG_DEBUG, "Trigger Channel update start");
+                TriggerChannelUpdate();
+                kodi::Log(ADDON_LOG_DEBUG, "Trigger Channel Groups update start");
+                TriggerChannelGroupsUpdate();
+              }
               // trigger EPG updates for all channels with a guide source
               kodi::Log(ADDON_LOG_DEBUG, "Trigger EPG update start");
               int channels = 0;


### PR DESCRIPTION
Store a hash of the XML channel list and if the hash changes after an EPG update trigger Kodi to reload the channel list and channel groups.  Use cache to remove obsolete channel icons. Add error checking to channel cache logic introduced in Piers.
