### PR TITLE
Fix custom genre strings

### DIFF
--- a/src/EPG.cpp
+++ b/src/EPG.cpp
@@ -121,7 +121,6 @@ PVR_ERROR EPG::GetEPGForChannel(int channelUid, time_t start, time_t end, kodi::
         // genre type
         broadcast.SetGenreType(XMLUtils::GetIntValue(pListingNode, "genre_type"));
         broadcast.SetGenreSubType(XMLUtils::GetIntValue(pListingNode, "genre_subtype"));
-
       }
 
       NextPVR::GenreBlock genreBlock = { sGenre, broadcast.GetGenreType(), EPG_EVENT_CONTENTMASK_UNDEFINED };

--- a/src/utilities/GenreMapper.cpp
+++ b/src/utilities/GenreMapper.cpp
@@ -24,7 +24,7 @@ GenreMapper::GenreMapper(const std::shared_ptr<InstanceSettings>& settings) : m_
 GenreMapper::~GenreMapper() {}
 
 
-bool GenreMapper::IsEnabled()
+bool GenreMapper::UseDvbGenre()
 {
   return !m_settings->m_genreString;
 }
@@ -66,7 +66,7 @@ bool GenreMapper::ParseAllGenres(const tinyxml2::XMLNode* node, GenreBlock& genr
   {
     if (allGenres.find(EPG_STRING_TOKEN_SEPARATOR) != std::string::npos)
     {
-      if (IsEnabled())
+      if (UseDvbGenre())
       {
         std::vector<std::string> genreCodes = kodi::tools::StringUtils::Split(allGenres, EPG_STRING_TOKEN_SEPARATOR);
         if (genreCodes.size() == 2)
@@ -86,17 +86,14 @@ bool GenreMapper::ParseAllGenres(const tinyxml2::XMLNode* node, GenreBlock& genr
       }
       if (genreBlock.genreSubType == EPG_EVENT_CONTENTMASK_UNDEFINED)
       {
-        if (genreBlock.genreType != EPG_GENRE_USE_STRING)
-        {
-          genreBlock.genreType = EPG_GENRE_USE_STRING;
-        }
+        genreBlock.genreSubType = EPG_GENRE_USE_STRING;
         genreBlock.description = allGenres;
       }
     }
-    else if (!IsEnabled() && genreBlock.genreSubType != EPG_GENRE_USE_STRING)
+    else if (!UseDvbGenre() && genreBlock.genreSubType != EPG_EVENT_CONTENTMASK_UNDEFINED)
     {
       genreBlock.description = allGenres;
-      genreBlock.genreType = EPG_GENRE_USE_STRING;
+      genreBlock.genreSubType = EPG_GENRE_USE_STRING;
     }
 
     return true;

--- a/src/utilities/GenreMapper.h
+++ b/src/utilities/GenreMapper.h
@@ -28,7 +28,7 @@ namespace NextPVR
     int GetGenreType(std::string code);
     int GetGenreSubType(std::string code);
     bool ParseAllGenres(const tinyxml2::XMLNode* node, GenreBlock& genreBlock);
-    bool IsEnabled();
+    bool UseDvbGenre();
 
   private:
     GenreMapper() = default;


### PR DESCRIPTION
For custom genre strings https://github.com/xbmc/xbmc/pull/16541 states that is GenreSubType that needs to be used.  Forum issue discussed here https://forum.kodi.tv/showthread.php?tid=380250
