### PR TITLE
Fix startup hang: always run the connection poll/reconnect thread

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -50,14 +50,12 @@ ADDON_STATUS CNextPVRAddon::CreateInstance(const kodi::addon::IInstanceInfo& ins
       client = new cPVRClientNextPVR(instance);
     }
 
-    status = client->Connect();
-
-    if (status != ADDON_STATUS_PERMANENT_FAILURE)
-    {
-      status = ADDON_STATUS_OK;
-      hdl = client;
-      m_usedInstances.emplace(std::make_pair(instance.GetID(), client));
-    }
+    // The client connects and maintains the connection on its own worker
+    // thread; connection problems are reported via the PVR connection state.
+    client->Start();
+    hdl = client;
+    m_usedInstances.emplace(std::make_pair(instance.GetID(), client));
+    status = ADDON_STATUS_OK;
   }
 
   return status;

--- a/src/pvrclient-nextpvr.cpp
+++ b/src/pvrclient-nextpvr.cpp
@@ -113,7 +113,6 @@ cPVRClientNextPVR::cPVRClientNextPVR(const kodi::addon::IInstanceInfo &instance)
   m_realTimeBuffer = new timeshift::DummyBuffer(m_settings, m_request);
   m_livePlayer = nullptr;
   m_nowPlaying = NotPlaying;
-  m_running = true;
 }
 
 cPVRClientNextPVR::~cPVRClientNextPVR()
@@ -135,8 +134,7 @@ cPVRClientNextPVR::~cPVRClientNextPVR()
       CloseLiveStream();
   }
 
-  m_running = false;
-  CThread::StopThread(2000);
+  StopThread();
   kodi::Log(ADDON_LOG_DEBUG, "->~cPVRClientNextPVR()");
   if (m_bConnected)
     Disconnect();
@@ -145,6 +143,14 @@ cPVRClientNextPVR::~cPVRClientNextPVR()
   m_recordings.m_hostFilenames.clear();
   m_channels.m_channelDetails.clear();
   m_channels.m_liveStreams.clear();
+}
+
+void cPVRClientNextPVR::Start()
+{
+  // Launch the worker thread, which performs the initial connection and then
+  // keeps polling/reconnecting. The thread is started here rather than in the
+  // constructor so construction has no side effects.
+  CreateThread();
 }
 
 ADDON_STATUS cPVRClientNextPVR::Connect(bool sendWOL)
@@ -186,28 +192,57 @@ ADDON_STATUS cPVRClientNextPVR::Connect(bool sendWOL)
       // login session
       std::string loginResponse;
       std::string request = kodi::tools::StringUtils::Format("session.login&sid=%s&md5=%s", sid.c_str(), md5.c_str());
+      doc->Clear();
       if (m_request.DoMethodRequest(request, *doc) == tinyxml2::XML_SUCCESS)
       {
         m_request.SetSID(sid);
-        CreateThread();
+        doc->Clear();
+        if (m_request.DoMethodRequest("setting.list", *doc) == tinyxml2::XML_SUCCESS)
+        {
+          if (m_settings->ReadBackendSettings(*doc) != ADDON_STATUS_OK)
+          {
+            m_request.DoActionRequest("session.logout");
+            // Not permanent (the backend can be upgraded), but not worth
+            // retrying either: a too-old backend won't fix itself and
+            // ReadBackendSettings re-notifies on every attempt. Leave the
+            // state sticky at VERSION_MISMATCH so IsUp() does not poll it; the
+            // instance stays alive and recovers on the next wake / settings
+            // change / restart.
+            SetConnectionState(PVR_CONNECTION_STATE_VERSION_MISMATCH, kodi::addon::GetLocalizedString(30050));
+            status = ADDON_STATUS_OK;
+            return status;
+          }
+        }
+        // set additional options based on the backend
+        ConfigurePostConnectionOptions();
+        m_channels.ResetChannelCache(m_lastEPGUpdateTime);
+        m_settings->SetConnection(true);
+        kodi::Log(ADDON_LOG_DEBUG, "session.login successful");
         status = ADDON_STATUS_OK;
-        return status;
+        // don't notify core could be before addon is created
+        m_bConnected = true;
+        SetConnectionState(PVR_CONNECTION_STATE_CONNECTED);
+      }
+      else
+      {
+        kodi::Log(ADDON_LOG_DEBUG, "session.login failed");
+        // Not permanent (the PIN can be corrected), but leave the state sticky
+        // at ACCESS_DENIED so IsUp() does not retry a known-bad credential. The
+        // instance stays alive and recovers on the next wake / settings change
+        // / restart.
+        SetConnectionState(PVR_CONNECTION_STATE_ACCESS_DENIED, kodi::addon::GetLocalizedString(30052));
+        status = ADDON_STATUS_OK;
       }
     }
   }
   else
   {
-    if (m_settings->m_connectionConfirmed || !m_settings->m_instancePriority)
-    {
-      status = ADDON_STATUS_OK;
-      // backend should continue to connnect and ignore client until reachable
-      UpdateServerCheck();
-      m_connectionState = PVR_CONNECTION_STATE_SERVER_UNREACHABLE;
-    }
-    else
-    {
-      status = ADDON_STATUS_PERMANENT_FAILURE;
-    }
+    // Backend not reachable. Keep the state retryable so the worker thread
+    // reconnects once the backend becomes available, instead of leaving the
+    // client wedged in CONNECTING.
+    status = ADDON_STATUS_OK;
+    UpdateServerCheck();
+    m_connectionState = PVR_CONNECTION_STATE_SERVER_UNREACHABLE;
   }
 
   return status;
@@ -431,35 +466,19 @@ bool cPVRClientNextPVR::IsUp()
 
 void cPVRClientNextPVR::Process()
 {
-  // Launch background thread — all slow post-login work and state
-  kodi::Log(ADDON_LOG_DEBUG, "Post success from CThread started");
-  auto doc = std::make_unique<tinyxml2::XMLDocument>();
-  if (m_request.DoMethodRequest("setting.list", *doc) == tinyxml2::XML_SUCCESS) {
-    if (m_settings->ReadBackendSettings(*doc) != ADDON_STATUS_OK) {
-      m_request.DoActionRequest("session.logout");
-      SetConnectionState(PVR_CONNECTION_STATE_VERSION_MISMATCH,
-                         kodi::addon::GetLocalizedString(30050));
-      return;
-    }
-    ConfigurePostConnectionOptions();
-    m_channels.ResetChannelCache(m_lastEPGUpdateTime);
-    m_settings->SetConnection(true);
-    m_bConnected = true;
-    SetConnectionState(PVR_CONNECTION_STATE_CONNECTED);
-    m_running = true;
-  } else {
-    kodi::Log(ADDON_LOG_DEBUG, "setting.list failed");
-    m_request.DoActionRequest("session.logout");
-    SetConnectionState(PVR_CONNECTION_STATE_UNKNOWN,
-                       kodi::addon::GetLocalizedString(30050));
-  }
-  while (m_running)
+  // Perform the initial connection on the worker thread so the slow backend
+  // handshake does not block instance creation.
+  Connect();
+
+  // Connection poll/retry loop. IsUp() reconnects after a dropped or initially
+  // failed session, so this must keep running regardless of connection state.
+  while (!m_threadStop)
   {
     IsUp();
     if (m_settings->m_heartbeatInterval == DEFAULT_HEARTBEAT)
-      std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+      Sleep(2500);
     else
-      std::this_thread::sleep_for(std::chrono::seconds(10));
+      Sleep(10000);
   }
 }
 

--- a/src/pvrclient-nextpvr.h
+++ b/src/pvrclient-nextpvr.h
@@ -50,6 +50,7 @@ public:
     const kodi::addon::CSettingValue& settingValue) override;
 
   /* Server handling */
+  void Start();
   ADDON_STATUS Connect(bool sendWOL = true);
   void Disconnect();
   void ResetConnection();
@@ -142,7 +143,6 @@ private:
   void ConfigurePostConnectionOptions();
 
   std::atomic<bool> m_bConnected{ false };
-  std::atomic<bool> m_running = { false };
   bool m_supportsLiveTimeshift;
 
   int m_timeShiftBufferSeconds;


### PR DESCRIPTION
Commit 77d4057922c4fdf0455f8d359805cf17c35653f8 moved connection setup off the main thread but gated the
worker thread's creation on a fully successful session.login: CreateThread()
was only called inside Connect() after both session.initiate and
session.login succeeded.

Because Process() is the only caller of IsUp(), and IsUp() is the only
code path that retries Connect() when the backend is unreachable, a failed
initial connection meant the thread was never started and the connection
was never retried. This is exactly what happens "soon after Kodi startup"
when the NextPVR backend or the network is not ready yet: the client stays
wedged in CONNECTING/SERVER_UNREACHABLE forever and Kodi hangs at
"Creating PVR clients".

The same design also reintroduced a crash: on a transient disconnect the
running worker thread would call IsUp() -> Connect(false) -> CreateThread()
from within its own thread while m_thread != nullptr, which CThread treats
as fatal (logs ADDON_LOG_FATAL and calls exit(1)).

Rework following the pvr.hts model (start the thread from a Start() command,
not the constructor):

- Constructor no longer starts a thread; construction has no side effects.
- Add Start(), which calls CreateThread(). CreateInstance() now constructs
  the client, calls Start(), registers it and returns ADDON_STATUS_OK; it no
  longer connects synchronously on the main thread.
- Process() performs the initial Connect() on the worker thread (so the slow
  backend handshake no longer blocks instance creation), then runs the
  poll/retry loop on !m_threadStop using the interruptible CThread::Sleep()
  so StopThread() returns promptly.
- Connect() establishes the full session in one place (setting.list,
  ReadBackendSettings, ConfigurePostConnectionOptions, SetConnection,
  CONNECTED) and reports failures through the PVR connection state rather than
  ADDON_STATUS_PERMANENT_FAILURE (which CreateInstance no longer consumes
  anyway, now that it registers the instance and returns OK unconditionally).
  An unreachable backend lands in a retryable SERVER_UNREACHABLE state so the
  worker reconnects once the backend becomes reachable again -- e.g. host
  networking/local nextpvr server that is not yet up at kodi startup, or a
  server taken down for maintenance. A rejected login (ACCESS_DENIED) or a
  too-old/incompatible backend (VERSION_MISMATCH) is reported with its
  specific reason and left sticky -- IsUp() does not poll those states -- so
  the user is informed without hammering a known-bad credential or
  re-notifying on every attempt; the instance stays alive and recovers on the
  next wake, settings change, or restart. Connect() no longer touches threads,
  removing the exit(1).
- Use StopThread() in the destructor; the previous StopThread(2000) passed
  2000 as the bool 'wait' argument, not a timeout.
- Remove the duplicate std::atomic<bool> m_running, which shadowed and
  collided with CThread's own private m_running member.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>